### PR TITLE
Fix/navbar

### DIFF
--- a/app/assets/stylesheets/components/_cursor.scss
+++ b/app/assets/stylesheets/components/_cursor.scss
@@ -1,0 +1,3 @@
+.pointer:hover {
+  cursor: pointer;
+} 

--- a/app/assets/stylesheets/components/_family.scss
+++ b/app/assets/stylesheets/components/_family.scss
@@ -23,10 +23,6 @@
     i {
       font-size: 24px;
       margin: 0 2rem 0 1rem;
-
-      &.pointer:hover {
-        cursor: pointer;
-      } 
     }
     p {
       margin-bottom: 0;

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,3 +3,4 @@
 @import "avatar";
 @import "navbar";
 @import "family";
+@import "cursor";

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,12 +1,12 @@
 .navbar-lewagon {
-  justify-content: space-between;
   background: white;
 }
-
-.navbar-lewagon .navbar-collapse {
-  flex-grow: 0;
+.navbar-expand-sm .navbar-nav {
+  width: 100%;
 }
 
-.navbar-lewagon .navbar-brand img {
-  width: 40px;
+@media (min-width: 576px) {
+  .navbar-expand-sm .navbar-nav {
+    width: 0;
+  }
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,12 +1,12 @@
 .navbar-lewagon {
   background: white;
 }
-.navbar-expand-sm .navbar-nav {
+.navbar-expand-sm .nav-collapse {
   width: 100%;
 }
 
 @media (min-width: 576px) {
-  .navbar-expand-sm .navbar-nav {
+  .navbar-expand-sm  .nav-collapse {
     width: 0;
   }
 }

--- a/app/javascript/react_app/containers/family_list.jsx
+++ b/app/javascript/react_app/containers/family_list.jsx
@@ -56,7 +56,7 @@ class FamilyList extends Component {
 
     return (
       <div>
-        <h1>All {totalFamilies} Swedish families: </h1>
+        <h1>All {totalFamilies} families: </h1>
         <h3 className="mb-3">
           Birds seen: ({totalSeen}/{totalBirds})
         </h3>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>RailsSwedishBirdsChecklist</title>
+    <title>Swedish Birds</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,35 +1,23 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
-  <%= link_to "#", class: "navbar-brand" do %>
-    <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
-    <% end %>
+  <%= link_to "Swedish Birds", "#", class: "navbar-brand" %>
 
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-
-
-  <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav mr-auto">
-      <% if user_signed_in? %>
-        <li class="nav-item active">
-          <%= link_to "Home", "#", class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
-        </li>
-        <li class="nav-item dropdown">
-          <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-            <%= link_to "Action", "#", class: "dropdown-item" %>
-            <%= link_to "Another action", "#", class: "dropdown-item" %>
-            <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
-          </div>
-        </li>
-      <% else %>
-        <li class="nav-item">
-          <%= link_to "Login", new_user_session_path, class: "nav-link" %>
-        </li>
-      <% end %>
+  <% if user_signed_in? %>
+    <%= image_tag "https://kitt.lewagon.com/placeholder/users/RyanofWoods", id: "dropdownMenuLink", class: "avatar ml-auto", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+    
+    <ul class="navbar-nav">
+      <li class="nav-item dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink" aria-labelledby="navbarDropdown">
+        <%# link_to "Settings", "#", class: "dropdown-item" %>
+        <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "nav-item dropdown-item" %>
+      </li>
     </ul>
-  </div>
+
+  <% else %>
+
+    <ul class="navbar-nav">
+      <li class="nav-item">
+        <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+      </li>
+    </ul>
+
+  <% end %>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,7 +2,7 @@
   <%= link_to "Swedish Birds", "#", class: "navbar-brand" %>
 
   <% if user_signed_in? %>
-    <%= image_tag "https://kitt.lewagon.com/placeholder/users/RyanofWoods", id: "dropdownMenuLink", class: "avatar ml-auto", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+    <%= image_tag "https://kitt.lewagon.com/placeholder/users/RyanofWoods", id: "dropdownMenuLink", class: "avatar ml-auto pointer", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
     
     <ul class="navbar-nav">
       <li class="nav-item dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink" aria-labelledby="navbarDropdown">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,7 +4,7 @@
   <% if user_signed_in? %>
     <%= image_tag "https://kitt.lewagon.com/placeholder/users/RyanofWoods", id: "dropdownMenuLink", class: "avatar ml-auto pointer", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
     
-    <ul class="navbar-nav">
+    <ul class="navbar-nav nav-collapse">
       <li class="nav-item dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink" aria-labelledby="navbarDropdown">
         <%# link_to "Settings", "#", class: "dropdown-item" %>
         <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "nav-item dropdown-item" %>
@@ -13,7 +13,7 @@
 
   <% else %>
 
-    <ul class="navbar-nav">
+    <ul class="navbar-nav ml-auto">
       <li class="nav-item">
         <%= link_to "Login", new_user_session_path, class: "nav-link" %>
       </li>


### PR DESCRIPTION
Fix the navbar interaction between collapse on mobile view and dropdown on screens bigger -> If you are logged in the image will stay in the top right. Normal interaction with this is that a dropdown appears, if the screen is small the options will be displayed like a navbar below the top one. 

The navbar image now has a pointer cursor on hover.
Also updated page title and title on family index page