### PR TITLE
Add/english name to order

### DIFF
--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::OrdersController < Api::V1::BaseController
     authorize @order
 
     @order_scientific_name = @order&.scientific_name
+    @order_english_name = @order&.english_name
     @order_swedish_name = @order&.swedish_name
     @order_birds = @order&.birds
     @total_birds = @order&.birds.count

--- a/app/javascript/react_app/components/group.jsx
+++ b/app/javascript/react_app/components/group.jsx
@@ -10,14 +10,6 @@ class Group extends Component {
       width: `${progress}%`,
     };
 
-    let groupText = '';
-
-    if (groupedBy === 'orders') {
-      groupText = `${scientific_name} / ${swedish_name}`
-    } else {
-      groupText = `${english_name} / ${swedish_name}`
-    }
-
     return (
       <Link to={`/${groupedBy}/${scientific_name}`}>
         <li className="list-group-item" id={scientific_name}>
@@ -28,7 +20,7 @@ class Group extends Component {
             ({total_seen}/{total_birds})
           </p>
           <p>
-            {groupText}
+            {english_name} / {swedish_name}
           </p>
         </li>
       </Link>

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,6 @@
 class Order < ApplicationRecord
-  validates :scientific_name, :swedish_name, presence: true
-  validates :scientific_name, :swedish_name, uniqueness: true
+  validates :scientific_name, :english_name, :swedish_name, presence: true
+  validates :scientific_name, :english_name, :swedish_name, uniqueness: true
 
   has_many :families
   has_many :birds, through: :families

--- a/app/views/api/v1/families/index.json.jbuilder
+++ b/app/views/api/v1/families/index.json.jbuilder
@@ -3,16 +3,13 @@ json.total_groups @total_groups
 json.total_birds @total_birds
 json.total_seen @total_seen
 
-if @group_by == 'family'
-  json.groups @groups do |family|
-    json.extract! family, :scientific_name, :english_name, :swedish_name
-    json.total_seen current_user.family_birds_seen_count(family)
-    json.total_birds family.birds.count
-  end
-elsif @group_by == 'order'
-  json.groups @groups do |order|
-    json.extract! order, :scientific_name, :swedish_name
-    json.total_seen current_user.order_birds_seen_count(order)
-    json.total_birds order.birds.count
+json.groups @groups do |group|
+  json.extract! group, :scientific_name, :english_name, :swedish_name
+  json.total_birds group.birds.count
+
+  if @group_by == 'family'
+    json.total_seen current_user.family_birds_seen_count(group)
+  elsif @group_by == 'order'
+    json.total_seen current_user.order_birds_seen_count(group)
   end
 end

--- a/app/views/api/v1/orders/show.json.jbuilder
+++ b/app/views/api/v1/orders/show.json.jbuilder
@@ -2,6 +2,7 @@ json.total_birds @total_birds
 json.total_seen @total_seen
 
 json.group_scientific_name @order_scientific_name
+json.group_english_name @order_english_name
 json.group_swedish_name @order_swedish_name
 
 json.birds @order_birds do |bird|

--- a/db/data/birds.csv
+++ b/db/data/birds.csv
@@ -1,544 +1,544 @@
-bird_scientific,bird_english,bird_swedish,family_scientific,family_english,family_swedish,order_scientific,order_swedish
-Branta bernicla,Brant Goose,prutgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Branta ruficollis,Red-breasted Goose,rödhalsad gås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Branta canadensis,Canada Goose,kanadagås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Branta leucopsis,Barnacle Goose,vitkindad gås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser rossii,Ross's Goose,dvärgsnögås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser caerulescens,Snow Goose,snögås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser anser,Greylag Goose,grågås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser fabalis,Bean Goose,sädgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser brachyrhynchus,Pink-footed Goose,spetsbergsgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser albifrons,Greater White-fronted Goose,bläsgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anser erythropus,Lesser White-fronted Goose,fjällgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Cygnus olor,Mute Swan,knölsvan,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Cygnus columbianus,Tundra Swan,mindre sångsvan,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Cygnus cygnus,Whooper Swan,sångsvan,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Alopochen aegyptiaca,Egyptian Goose,nilgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Tadorna tadorna,Common Shelduck,gravand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Tadorna ferruginea,Ruddy Shelduck,rostand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas formosa,Baikal Teal,gulkindad kricka,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas querquedula,Garganey,årta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas discors,Blue-winged Teal,blåvingad årta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas clypeata,Northern Shoveler,skedand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas strepera,Gadwall,snatterand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas falcata,Falcated Duck,praktand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas penelope,Eurasian Wigeon,bläsand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas americana,American Wigeon,amerikansk bläsand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas platyrhynchos,Mallard,gräsand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas rubripes,American Black Duck,svartand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas acuta,Northern Pintail,stjärtand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas crecca,Eurasian Teal,kricka,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Anas carolinensis,Green-winged Teal,amerikansk kricka,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Netta rufina,Red-crested Pochard,rödhuvad dykand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Aythya ferina,Common Pochard,brunand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Aythya nyroca,Ferruginous Duck,vitögd dykand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Aythya collaris,Ring-necked Duck,ringand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Aythya fuligula,Tufted Duck,vigg,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Aythya marila,Greater Scaup,bergand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Aythya affinis,Lesser Scaup,mindre bergand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Polysticta stelleri,Steller's Eider,alförrädare,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Somateria spectabilis,King Eider,praktejder,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Somateria mollissima,Common Eider,ejder,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Histrionicus histrionicus,Harlequin Duck,strömand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Melanitta perspicillata,Surf Scoter,vitnackad svärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Melanitta fusca,Velvet Scoter,svärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Melanitta deglandi,White-winged Scoter,amerikansk knölsvärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Melanitta stejnegeri,Stejneger's Scoter,sibirisk knölsvärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Melanitta nigra,Common Scoter,sjöorre,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Melanitta americana,Black Scoter,amerikansk sjöorre,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Clangula hyemalis,Long-tailed Duck,alfågel,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Bucephala albeola,Bufflehead,buffelhuvud,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Bucephala clangula,Common Goldeneye,knipa,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Mergellus albellus,Smew,salskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Lophodytes cucullatus,Hooded Merganser,kamskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Mergus merganser,Common Merganser,storskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Mergus serrator,Red-breasted Merganser,småskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Oxyura jamaicensis,Ruddy Duck,amerikansk kopparand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Oxyura leucocephala,White-headed Duck,kopparand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,ANDFÅGLAR
-Tetrastes bonasia,Hazel Grouse,järpe,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Tetrao urogallus,Western Capercaillie,tjäder,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Lyrurus tetrix,Black Grouse,orre,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Lagopus muta,Rock Ptarmigan,fjällripa,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Lagopus lagopus,Willow Ptarmigan,dalripa,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Perdix perdix,Grey Partridge,rapphöna,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Coturnix coturnix,Common Quail,vaktel,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Phasianus colchicus,Common Pheasant,fasan,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,HÖNSFÅGLAR
-Caprimulgus europaeus,European Nightjar,nattskärra,Caprimulgidae,Nightjars,Nattskärror,CAPRIMULGIFORMES,SKÄRRFÅGLAR
-Caprimulgus aegyptius,Egyptian Nightjar,ökennattskärra,Caprimulgidae,Nightjars,Nattskärror,CAPRIMULGIFORMES,SKÄRRFÅGLAR
-Hirundapus caudacutus,White-throated Needletail,taggstjärtseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Chaetura pelagica,Chimney Swift,skorstensseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Apus melba,Alpine Swift,alpseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Apus apus,Common Swift,tornseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Apus pallidus,Pallid Swift,blek tornseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Apus pacificus,Pacific Swift,orientseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Apus affinis,Little Swift,stubbstjärtseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Apus caffer,White-rumped Swift,vitgumpseglare,Apodidae,Swifts,Seglare,APODIFORMES,SEGLAR- OCH KOLIBRIFÅGLAR
-Otis tarda,Great Bustard,stortrapp,Otididae,Bustards,Trappar,OTIDIFORMES,TRAPPFÅGLAR
-Chlamydotis macqueenii,Macqueen's Bustard,kragtrapp,Otididae,Bustards,Trappar,OTIDIFORMES,TRAPPFÅGLAR
-Tetrax tetrax,Little Bustard,småtrapp,Otididae,Bustards,Trappar,OTIDIFORMES,TRAPPFÅGLAR
-Clamator glandarius,Great Spotted Cuckoo,skatgök,Cuculidae,Cuckoos,Gökar,CUCULIFORMES,GÖKFÅGLAR
-Cuculus canorus,Common Cuckoo,gök,Cuculidae,Cuckoos,Gökar,CUCULIFORMES,GÖKFÅGLAR
-Syrrhaptes paradoxus,Pallas's Sandgrouse,stäppflyghöna,Pteroclidae,Sandgrouse,Flyghöns,PTEROCLIFORMES,FLYGHÖNSFÅGLAR
-Columba livia,Rock Dove / Feral Pigeon,klippduva / tamduva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Columba oenas,Stock Dove,skogsduva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Columba palumbus,Common Wood Pigeon,ringduva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Streptopelia turtur,European Turtle Dove,turturduva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Streptopelia orientalis,Oriental Turtle Dove,större turturduva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Streptopelia decaocto,Eurasian Collared Dove,turkduva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Zenaida macroura,Mourning Dove,spetsstjärtad duva,Columbidae,"Pigeons, Doves",Duvor,COLUMBIFORMES,DUVFÅGLAR
-Rallus aquaticus,Water Rail,vattenrall,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Crex crex,Corn Crake,kornknarr,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Porzana carolina,Sora,karolinasumphöna,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Porzana porzana,Spotted Crake,småfläckig sumphöna,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Gallinula chloropus,Common Moorhen,rörhöna,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Fulica atra,Eurasian Coot,sothöna,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Zapornia pusilla,Baillon's Crake,dvärgsumphöna,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Zapornia parva,Little Crake,mindre sumphöna,Rallidae,"Rails, Crakes and Coots",Rallar,GRUIFORMES,TRANFÅGLAR
-Grus canadensis,Sandhill Crane,prärietrana,Gruidae,Cranes,Tranor,GRUIFORMES,TRANFÅGLAR
-Grus virgo,Demoiselle Crane,jungfrutrana,Gruidae,Cranes,Tranor,GRUIFORMES,TRANFÅGLAR
-Grus grus,Common Crane,trana,Gruidae,Cranes,Tranor,GRUIFORMES,TRANFÅGLAR
-Tachybaptus ruficollis,Little Grebe,smådopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,DOPPINGFÅGLAR
-Podiceps grisegena,Red-necked Grebe,gråhakedopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,DOPPINGFÅGLAR
-Podiceps cristatus,Great Crested Grebe,skäggdopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,DOPPINGFÅGLAR
-Podiceps auritus,Horned Grebe,svarthakedopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,DOPPINGFÅGLAR
-Podiceps nigricollis,Black-necked Grebe,svarthalsad dopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,DOPPINGFÅGLAR
-Phoenicopterus roseus,Greater Flamingo,större flamingo,Phoenicopteridae,Flamingos,Flamingor,PHOENICOPTERIFORMES,FLAMINGOFÅGLAR
-Burhinus oedicnemus,Eurasian Stone-curlew,tjockfot,Burhinidae,"Stone-curlews, Thick-knees",Tjockfotar,CHARADRIIFORMES,VADARFÅGLAR
-Haematopus ostralegus,Eurasian Oystercatcher,strandskata,Haematopodidae,Oystercatchers,Strandskator,CHARADRIIFORMES,VADARFÅGLAR
-Himantopus himantopus,Black-winged Stilt,styltlöpare,Recurvirostridae,"Stilts, Avocets",Skärfläckor,CHARADRIIFORMES,VADARFÅGLAR
-Recurvirostra avosetta,Pied Avocet,skärfläcka,Recurvirostridae,"Stilts, Avocets",Skärfläckor,CHARADRIIFORMES,VADARFÅGLAR
-Vanellus vanellus,Northern Lapwing,tofsvipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Vanellus cinereus,Grey-headed Lapwing,gråhuvad vipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Vanellus gregarius,Sociable Lapwing,stäppvipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Vanellus leucurus,White-tailed Lapwing,sumpvipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Pluvialis apricaria,European Golden Plover,ljungpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Pluvialis fulva,Pacific Golden Plover,sibirisk tundrapipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Pluvialis dominica,American Golden Plover,amerikansk tundrapipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Pluvialis squatarola,Grey Plover,kustpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius hiaticula,Common Ringed Plover,större strandpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius dubius,Little Ringed Plover,mindre strandpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius alexandrinus,Kentish Plover,svartbent strandpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius mongolus,Lesser Sand Plover,mongolpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius leschenaultii,Greater Sand Plover,ökenpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius asiaticus,Caspian Plover,kaspisk pipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Charadrius morinellus,Eurasian Dotterel,fjällpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,VADARFÅGLAR
-Bartramia longicauda,Upland Sandpiper,piparsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Numenius phaeopus,Eurasian Whimbrel,småspov,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Numenius minutus,Little Curlew,dvärgspov,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Numenius arquata,Eurasian Curlew,storspov,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Limosa lapponica,Bar-tailed Godwit,myrspov,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Limosa limosa,Black-tailed Godwit,rödspov,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Limosa haemastica,Hudsonian Godwit,hudsonspov,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Arenaria interpres,Ruddy Turnstone,roskarl,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris tenuirostris,Great Knot,kolymasnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris canutus,Red Knot,kustsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris pugnax,Ruff,brushane,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris falcinellus,Broad-billed Sandpiper,myrsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris acuminata,Sharp-tailed Sandpiper,spetsstjärtad snäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris himantopus,Stilt Sandpiper,styltsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris ferruginea,Curlew Sandpiper,spovsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris temminckii,Temminck's Stint,mosnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris subminuta,Long-toed Stint,långtåsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris ruficollis,Red-necked Stint,rödhalsad snäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris alba,Sanderling,sandlöpare,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris alpina,Dunlin,kärrsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris maritima,Purple Sandpiper,skärsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris bairdii,Baird's Sandpiper,gulbröstad snäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris minuta,Little Stint,småsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris fuscicollis,White-rumped Sandpiper,vitgumpsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris subruficollis,Buff-breasted Sandpiper,prärielöpare,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris melanotos,Pectoral Sandpiper,tuvsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris pusilla,Semipalmated Sandpiper,sandsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Calidris mauri,Western Sandpiper,tundrasnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Limnodromus scolopaceus,Long-billed Dowitcher,större beckasinsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Limnodromus griseus,Short-billed Dowitcher,mindre beckasinsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Scolopax rusticola,Eurasian Woodcock,morkulla,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Lymnocryptes minimus,Jack Snipe,dvärgbeckasin,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Gallinago media,Great Snipe,dubbelbeckasin,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Gallinago gallinago,Common Snipe,enkelbeckasin,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Gallinago delicata,Wilson's Snipe,wilsonbeckasin,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Xenus cinereus,Terek Sandpiper,tereksnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Phalaropus tricolor,Wilson's Phalarope,wilsonsimsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Phalaropus lobatus,Red-necked Phalarope,smalnäbbad simsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Phalaropus fulicarius,Red Phalarope,brednäbbad simsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Actitis hypoleucos,Common Sandpiper,drillsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Actitis macularius,Spotted Sandpiper,fläckdrillsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa ochropus,Green Sandpiper,skogssnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa solitaria,Solitary Sandpiper,amerikansk skogssnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa brevipes,Grey-tailed Tattler,sibirisk gråsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa flavipes,Lesser Yellowlegs,mindre gulbena,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa totanus,Common Redshank,rödbena,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa stagnatilis,Marsh Sandpiper,dammsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa glareola,Wood Sandpiper,grönbena,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa erythropus,Spotted Redshank,svartsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa nebularia,Common Greenshank,gluttsnäppa,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Tringa melanoleuca,Greater Yellowlegs,större gulbena,Scolopacidae,"Sandpipers, Snipes",Snäppor,CHARADRIIFORMES,VADARFÅGLAR
-Cursorius cursor,Cream-colored Courser,ökenlöpare,Glareolidae,"Coursers, Pratincoles",Vadarsvalor,CHARADRIIFORMES,VADARFÅGLAR
-Glareola pratincola,Collared Pratincole,rödvingad vadarsvala,Glareolidae,"Coursers, Pratincoles",Vadarsvalor,CHARADRIIFORMES,VADARFÅGLAR
-Glareola maldivarum,Oriental Pratincole,orientvadarsvala,Glareolidae,"Coursers, Pratincoles",Vadarsvalor,CHARADRIIFORMES,VADARFÅGLAR
-Glareola nordmanni,Black-winged Pratincole,svartvingad vadarsvala,Glareolidae,"Coursers, Pratincoles",Vadarsvalor,CHARADRIIFORMES,VADARFÅGLAR
-Rissa tridactyla,Black-legged Kittiwake,tretåig mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Pagophila eburnea,Ivory Gull,ismås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Xema sabini,Sabine's Gull,tärnmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Chroicocephalus genei,Slender-billed Gull,långnäbbad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Chroicocephalus philadelphia,Bonaparte's Gull,trädmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Chroicocephalus ridibundus,Black-headed Gull,skrattmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Hydrocoloeus minutus,Little Gull,dvärgmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Rhodostethia rosea,Ross's Gull,rosenmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Leucophaeus atricilla,Laughing Gull,sotvingad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Leucophaeus pipixcan,Franklin's Gull,präriemås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Ichthyaetus melanocephalus,Mediterranean Gull,svarthuvad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Ichthyaetus ichthyaetus,Pallas's Gull,svarthuvad trut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus canus,Mew Gull,fiskmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus delawarensis,Ring-billed Gull,ringnäbbad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus marinus,Great Black-backed Gull,havstrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus hyperboreus,Glaucous Gull,vittrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus glaucoides,Iceland Gull,vitvingad trut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus argentatus,Herring Gull,gråtrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus cachinnans,Caspian Gull,kaspisk trut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus michahellis,Yellow-legged Gull,medelhavstrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Larus fuscus,Lesser Black-backed Gull,silltrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Gelochelidon nilotica,Gull-billed Tern,sandtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Hydroprogne caspia,Caspian Tern,skräntärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Thalasseus sandvicensis,Sandwich Tern,kentsk tärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Sternula albifrons,Little Tern,småtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Onychoprion anaethetus,Bridled Tern,tygeltärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Onychoprion fuscatus,Sooty Tern,sottärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Sterna dougallii,Roseate Tern,rosentärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Sterna hirundo,Common Tern,fisktärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Sterna paradisaea,Arctic Tern,silvertärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Sterna forsteri,Forster's Tern,kärrtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Chlidonias hybrida,Whiskered Tern,skäggtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Chlidonias leucopterus,White-winged Tern,vitvingad tärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Chlidonias niger,Black Tern,svarttärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,VADARFÅGLAR
-Stercorarius skua,Great Skua,storlabb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,VADARFÅGLAR
-Stercorarius pomarinus,Pomarine Jaeger,bredstjärtad labb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,VADARFÅGLAR
-Stercorarius parasiticus,Parasitic Jaeger,kustlabb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,VADARFÅGLAR
-Stercorarius longicaudus,Long-tailed Jaeger,fjällabb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,VADARFÅGLAR
-Alle alle,Little Auk,alkekung,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Uria lomvia,Thick-billed Murre,spetsbergsgrissla,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Uria aalge,Common Murre,sillgrissla,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Alca torda,Razorbill,tordmule,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Pinguinus impennis,Great Auk,garfågel,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Cepphus grylle,Black Guillemot,tobisgrissla,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Aethia psittacula,Parakeet Auklet,papegojalka,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Fratercula arctica,Atlantic Puffin,lunnefågel,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Fratercula cirrhata,Tufted Puffin,tofslunne,Alcidae,Auks,Alkor,CHARADRIIFORMES,VADARFÅGLAR
-Gavia stellata,Red-throated Loon,smålom,Gaviidae,Loons,Lommar,GAVIIFORMES,LOMFÅGLAR
-Gavia arctica,Black-throated Loon,storlom,Gaviidae,Loons,Lommar,GAVIIFORMES,LOMFÅGLAR
-Gavia pacifica,Pacific Loon,stillahavslom,Gaviidae,Loons,Lommar,GAVIIFORMES,LOMFÅGLAR
-Gavia immer,Common Loon,svartnäbbad islom,Gaviidae,Loons,Lommar,GAVIIFORMES,LOMFÅGLAR
-Gavia adamsii,Yellow-billed Loon,vitnäbbad islom,Gaviidae,Loons,Lommar,GAVIIFORMES,LOMFÅGLAR
-Thalassarche melanophris,Black-browed Albatross,svartbrynad albatross,Diomedeidae,Albatrosses,Albatrosser,PROCELLARIIFORMES,STORMFÅGLAR
-Thalassarche chlororhynchos,Yellow-nosed Albatross,mindre albatross,Diomedeidae,Albatrosses,Albatrosser,PROCELLARIIFORMES,STORMFÅGLAR
-Hydrobates pelagicus,European Storm Petrel,stormsvala,Hydrobatidae,Northern Storm Petrels,Nordstormsvalor,PROCELLARIIFORMES,STORMFÅGLAR
-Oceanodroma leucorhoa,Leach's Storm Petrel,klykstjärtad stormsvala,Hydrobatidae,Northern Storm Petrels,Nordstormsvalor,PROCELLARIIFORMES,STORMFÅGLAR
-Fulmarus glacialis,Northern Fulmar,stormfågel,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Pterodroma feae/madeira,Fea's Petrel/Zino's Petrel,atlantpetrell/madeirapetrell,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Calonectris borealis/diomedea,Cory's/Scopoli's Shearwater,gulnäbbad lira/scopolilira,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Ardenna grisea,Sooty Shearwater,grålira,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Ardenna gravis,Great Shearwater,större lira,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Puffinus puffinus,Manx Shearwater,mindre lira,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Puffinus mauretanicus,Balearic Shearwater,balearisk lira,Procellariidae,"Petrels, Shearwaters",Liror,PROCELLARIIFORMES,STORMFÅGLAR
-Ciconia nigra,Black Stork,svart stork,Ciconiidae,Storks,Storkar,CICONIIFORMES,STORKFÅGLAR
-Ciconia ciconia,White Stork,vit stork,Ciconiidae,Storks,Storkar,CICONIIFORMES,STORKFÅGLAR
-Fregata magnificens,Magnificent Frigatebird,praktfregattfågel,Fregatidae,Frigatebirds,Fregattfåglar,SULIFORMES,SULFÅGLAR
-Morus bassanus,Northern Gannet,havssula,Sulidae,"Gannets, Boobies",Sulor,SULIFORMES,SULFÅGLAR
-Microcarbo pygmaeus,Pygmy Cormorant,dvärgskarv,Phalacrocoracidae,"Cormorants, Shags",Skarvar,SULIFORMES,SULFÅGLAR
-Phalacrocorax carbo,Great Cormorant,storskarv,Phalacrocoracidae,"Cormorants, Shags",Skarvar,SULIFORMES,SULFÅGLAR
-Phalacrocorax aristotelis,European Shag,toppskarv,Phalacrocoracidae,"Cormorants, Shags",Skarvar,SULIFORMES,SULFÅGLAR
-Plegadis falcinellus,Glossy Ibis,bronsibis,Threskiornithidae,"Ibises, Spoonbills",Ibisar,PELECANIFORMES,PELIKANFÅGLAR
-Platalea leucorodia,Eurasian Spoonbill,skedstork,Threskiornithidae,"Ibises, Spoonbills",Ibisar,PELECANIFORMES,PELIKANFÅGLAR
-Botaurus stellaris,Eurasian Bittern,rördrom,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Botaurus lentiginosus,American Bittern,amerikansk rördrom,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Ixobrychus minutus,Little Bittern,dvärgrördrom,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Nycticorax nycticorax,Black-crowned Night Heron,natthäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Ardeola ralloides,Squacco Heron,rallhäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Bubulcus ibis,Cattle Egret,kohäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Ardea cinerea,Grey Heron,gråhäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Ardea purpurea,Purple Heron,purpurhäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Ardea alba,Great Egret,ägretthäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Egretta garzetta,Little Egret,silkeshäger,Ardeidae,"Herons, Bitterns",Hägrar,PELECANIFORMES,PELIKANFÅGLAR
-Pelecanus onocrotalus,Great White Pelican,vit pelikan,Pelecanidae,Pelicans,Pelikaner,PELECANIFORMES,PELIKANFÅGLAR
-Pandion haliaetus,Osprey,fiskgjuse,Pandionidae,Ospreys,Fiskgjusar,ACCIPITRIFORMES,HÖKFÅGLAR
-Elanus caeruleus,Black-winged Kite,svartvingad glada,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Neophron percnopterus,Egyptian Vulture,smutsgam,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Pernis apivorus,European Honey Buzzard,bivråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Gyps fulvus,Griffon Vulture,gåsgam,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Aegypius monachus,Cinereous Vulture,grågam,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Circaetus gallicus,Short-toed Snake Eagle,ormörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Clanga pomarina,Lesser Spotted Eagle,mindre skrikörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Clanga clanga,Greater Spotted Eagle,större skrikörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Hieraaetus pennatus,Booted Eagle,dvärgörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Aquila nipalensis,Steppe Eagle,stäppörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Aquila heliaca,Eastern Imperial Eagle,kejsarörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Aquila chrysaetos,Golden Eagle,kungsörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Accipiter nisus,Eurasian Sparrowhawk,sparvhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Accipiter gentilis,Northern Goshawk,duvhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Circus aeruginosus,Western Marsh Harrier,brun kärrhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Circus cyaneus,Hen Harrier,blå kärrhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Circus macrourus,Pallid Harrier,stäpphök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Circus pygargus,Montagu's Harrier,ängshök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Milvus milvus,Red Kite,röd glada,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Milvus migrans,Black Kite,brun glada,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Haliaeetus albicilla,White-tailed Eagle,havsörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Buteo lagopus,Rough-legged Buzzard,fjällvråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Buteo rufinus,Long-legged Buzzard,örnvråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Buteo buteo,Common Buzzard,ormvråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,HÖKFÅGLAR
-Tyto alba,Western Barn Owl,tornuggla,Tytonidae,Barn Owls,Tornugglor,STRIGIFORMES,UGGLEFÅGLAR
-Otus scops,Eurasian Scops Owl,dvärguv,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Bubo scandiacus,Snowy Owl,fjälluggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Bubo bubo,Eurasian Eagle-Owl,berguv,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Strix aluco,Tawny Owl,kattuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Strix uralensis,Ural Owl,slaguggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Strix nebulosa,Great Grey Owl,lappuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Surnia ulula,Northern Hawk-Owl,hökuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Glaucidium passerinum,Eurasian Pygmy Owl,sparvuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Athene noctua,Little Owl,minervauggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Aegolius funereus,Boreal Owl,pärluggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Asio otus,Long-eared Owl,hornuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Asio flammeus,Short-eared Owl,jorduggla,Strigidae,Owls,Ugglor,STRIGIFORMES,UGGLEFÅGLAR
-Upupa epops,Eurasian Hoopoe,härfågel,Upupidae,Hoopoes,Härfåglar,BUCEROTIFORMES,HÄRFÅGLAR OCH NÄSHORNSFÅGLAR
-Coracias garrulus,European Roller,blåkråka,Coraciidae,Rollers,Blåkråkor,CORACIIFORMES,PRAKTFÅGLAR
-Alcedo atthis,Common Kingfisher,kungsfiskare,Alcedinidae,Kingfishers,Kungsfiskare,CORACIIFORMES,PRAKTFÅGLAR
-Merops persicus,Blue-cheeked Bee-eater,grön biätare,Meropidae,Bee-eaters,Biätare,CORACIIFORMES,PRAKTFÅGLAR
-Merops apiaster,European Bee-eater,biätare,Meropidae,Bee-eaters,Biätare,CORACIIFORMES,PRAKTFÅGLAR
-Jynx torquilla,Eurasian Wryneck,göktyta,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Picoides tridactylus,Eurasian Three-toed Woodpecker,tretåig hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Dendrocoptes medius,Middle Spotted Woodpecker,mellanspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Dryobates minor,Lesser Spotted Woodpecker,mindre hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Dendrocopos major,Great Spotted Woodpecker,större hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Dendrocopos leucotos,White-backed Woodpecker,vitryggig hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Dryocopus martius,Black Woodpecker,spillkråka,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Picus viridis,European Green Woodpecker,gröngöling,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Picus canus,Grey-headed Woodpecker,gråspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,HACKSPETTARTADE FÅGLAR
-Falco naumanni,Lesser Kestrel,rödfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco tinnunculus,Common Kestrel,tornfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco vespertinus,Red-footed Falcon,aftonfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco amurensis,Amur Falcon,amurfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco eleonorae,Eleonora's Falcon,eleonorafalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco columbarius,Merlin,stenfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco subbuteo,Eurasian Hobby,lärkfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco cherrug,Saker Falcon,tatarfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco rusticolus,Gyrfalcon,jaktfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Falco peregrinus,Peregrine Falcon,pilgrimsfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,FALKFÅGLAR
-Lanius cristatus,Brown Shrike,brun törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius collurio,Red-backed Shrike,törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius isabellinus,Isabelline Shrike,isabellatörnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius phoenicuroides,Red-tailed Shrike,turkestantörnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius schach,Long-tailed Shrike,rostgumpad törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius minor,Lesser Grey Shrike,svartpannad törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius excubitor,Great Grey Shrike,varfågel,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius elegans,Southern Grey Shrike,ökenvarfågel,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius senator,Woodchat Shrike,rödhuvad törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Lanius nubicus,Masked Shrike,masktörnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,TÄTTINGAR
-Oriolus oriolus,Eurasian Golden Oriole,sommargylling,Oriolidae,Orioles,Gyllingar,PASSERIFORMES,TÄTTINGAR
-Perisoreus infaustus,Siberian Jay,lavskrika,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Garrulus glandarius,Eurasian Jay,nötskrika,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Pica pica,Eurasian Magpie,skata,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Nucifraga caryocatactes,Spotted Nutcracker,nötkråka,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Pyrrhocorax graculus,Alpine Chough,alpkaja,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Corvus monedula,Western Jackdaw,kaja,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Corvus dauuricus,Daurian Jackdaw,klippkaja,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Corvus frugilegus,Rook,råka,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Corvus corone,Carrion Crow,kråka,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Corvus corax,Northern Raven,korp,Corvidae,"Crows, Jays",Kråkor,PASSERIFORMES,TÄTTINGAR
-Bombycilla garrulus,Bohemian Waxwing,sidensvans,Bombycillidae,Waxwings,Sidensvansar,PASSERIFORMES,TÄTTINGAR
-Periparus ater,Coal Tit,svartmes,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Lophophanes cristatus,European Crested Tit,tofsmes,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Poecile cinctus,Grey-headed Chickadee,lappmes,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Poecile palustris,Marsh Tit,entita,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Poecile montanus,Willow Tit,talltita,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Cyanistes caeruleus,Eurasian Blue Tit,blåmes,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Cyanistes cyanus,Azure Tit,azurmes,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Parus major,Great Tit,talgoxe,Paridae,Tits,Mesar,PASSERIFORMES,TÄTTINGAR
-Remiz pendulinus,Eurasian Penduline Tit,pungmes,Remizidae,Penduline Tits,Pungmesar,PASSERIFORMES,TÄTTINGAR
-Panurus biarmicus,Bearded Reedling,skäggmes,Panuridae,Bearded Reedling,Skäggmesar,PASSERIFORMES,TÄTTINGAR
-Lullula arborea,Woodlark,trädlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Alauda leucoptera,White-winged Lark,vitvingad lärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Alauda arvensis,Eurasian Skylark,sånglärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Galerida cristata,Crested Lark,tofslärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Eremophila alpestris,Common Horned Lark,berglärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Calandrella brachydactyla,Greater Short-toed Lark,korttålärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Melanocorypha bimaculata,Bimaculated Lark,asiatisk kalanderlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Melanocorypha calandra,Calandra Lark,kalanderlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Melanocorypha yeltoniensis,Black Lark,svartlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Alaudala rufescens,Lesser Short-toed Lark,dvärglärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,TÄTTINGAR
-Riparia riparia,Sand Martin,backsvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,TÄTTINGAR
-Hirundo rustica,Barn Swallow,ladusvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,TÄTTINGAR
-Ptyonoprogne rupestris,Eurasian Crag Martin,klippsvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,TÄTTINGAR
-Delichon urbicum,Common House Martin,hussvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,TÄTTINGAR
-Cecropis daurica,Red-rumped Swallow,rostgumpsvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,TÄTTINGAR
-Petrochelidon pyrrhonota,American Cliff Swallow,stensvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,TÄTTINGAR
-Cettia cetti,Cetti's Warbler,cettisångare,Cettiidae,Cettia Bush Warblers,Cettisångare,PASSERIFORMES,TÄTTINGAR
-Aegithalos caudatus,Long-tailed Tit,stjärtmes,Aegithalidae,Bushtits,Stjärtmesar,PASSERIFORMES,TÄTTINGAR
-Phylloscopus sibilatrix,Wood Warbler,grönsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus bonelli,Western Bonelli's Warbler,bergsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus orientalis,Eastern Bonelli's Warbler,balkansångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus humei,Hume's Leaf Warbler,bergtajgasångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus inornatus,Yellow-browed Warbler,tajgasångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus proregulus,Pallas's Leaf Warbler,kungsfågelsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus schwarzi,Radde's Warbler,videsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus fuscatus,Dusky Warbler,brunsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus neglectus,Plain Leaf Warbler,dvärgsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus trochilus,Willow Warbler,lövsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus collybita,Common Chiffchaff,gransångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus ibericus,Iberian Chiffchaff,iberisk gransångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus coronatus,Eastern Crowned Warbler,östlig kronsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus nitidus,Green Warbler,kaukasisk lundsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus plumbeitarsus,Two-barred Warbler,sibirisk lundsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus trochiloides,Greenish Warbler,lundsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Phylloscopus borealis,Arctic Warbler,nordsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus arundinaceus,Great Reed Warbler,trastsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus paludicola,Aquatic Warbler,vattensångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus schoenobaenus,Sedge Warbler,sävsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus agricola,Paddyfield Warbler,fältsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus dumetorum,Blyth's Reed Warbler,busksångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus scirpaceus,Eurasian Reed Warbler,rörsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Acrocephalus palustris,Marsh Warbler,kärrsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Iduna caligata,Booted Warbler,stäppsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Iduna rama,Sykes's Warbler,saxaulsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Iduna pallida,Eastern Olivaceous Warbler,eksångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Iduna opaca,Western Olivaceous Warbler,macchiasångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Hippolais polyglotta,Melodious Warbler,polyglottsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Hippolais icterina,Icterine Warbler,härmsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,TÄTTINGAR
-Helopsaltes certhiola,Pallas's Grasshopper Warbler,starrsångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,TÄTTINGAR
-Locustella lanceolata,Lanceolated Warbler,träsksångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,TÄTTINGAR
-Locustella fluviatilis,River Warbler,flodsångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,TÄTTINGAR
-Locustella luscinioides,Savi's Warbler,vassångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,TÄTTINGAR
-Locustella naevia,Common Grasshopper Warbler,gräshoppsångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,TÄTTINGAR
-Cisticola juncidis,Zitting Cisticola,grässångare,Cisticolidae,Cisticolas and allies,Cistikolor,PASSERIFORMES,TÄTTINGAR
-Sylvia atricapilla,Eurasian Blackcap,svarthätta,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Sylvia borin,Garden Warbler,trädgårdssångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca nisoria,Barred Warbler,höksångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca curruca,Lesser Whitethroat,ärtsångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca nana,Asian Desert Warbler,ökensångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca melanocephala,Sardinian Warbler,sammetshätta,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca iberiae,Western Subalpine Warbler,rostsångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca subalpina,Moltoni's Warbler,moltonisångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca cantillans,Eastern Subalpine Warbler,rödstrupig sångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca communis,Common Whitethroat,törnsångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Curruca undata,Dartford Warbler,provencesångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,TÄTTINGAR
-Regulus ignicapilla,Common Firecrest,brandkronad kungsfågel,Regulidae,"Goldcrests, Kinglets",Kungsfåglar,PASSERIFORMES,TÄTTINGAR
-Regulus regulus,Goldcrest,kungsfågel,Regulidae,"Goldcrests, Kinglets",Kungsfåglar,PASSERIFORMES,TÄTTINGAR
-Troglodytes troglodytes,Eurasian Wren,gärdsmyg,Troglodytidae,Wrens,Gärdsmygar,PASSERIFORMES,TÄTTINGAR
-Sitta europaea,Eurasian Nuthatch,nötväcka,Sittidae,Nuthatches,Nötväckor,PASSERIFORMES,TÄTTINGAR
-Certhia familiaris,Eurasian Treecreeper,trädkrypare,Certhiidae,Treecreepers,Trädkrypare,PASSERIFORMES,TÄTTINGAR
-Certhia brachydactyla,Short-toed Treecreeper,trädgårdsträdkrypare,Certhiidae,Treecreepers,Trädkrypare,PASSERIFORMES,TÄTTINGAR
-Pastor roseus,Rosy Starling,rosenstare,Sturnidae,"Starlings, Rhabdornis",Starar,PASSERIFORMES,TÄTTINGAR
-Sturnus vulgaris,Common Starling,stare,Sturnidae,"Starlings, Rhabdornis",Starar,PASSERIFORMES,TÄTTINGAR
-Geokichla sibirica,Siberian Thrush,sibirisk trast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Zoothera aurea,White's Thrush,guldtrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Catharus fuscescens,Veery,rostskogstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Catharus ustulatus,Swainson's Thrush,beigekindad skogstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Catharus guttatus,Hermit Thrush,eremitskogstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus torquatus,Ring Ouzel,ringtrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus merula,Common Blackbird,koltrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus obscurus,Eyebrowed Thrush,gråhalsad trast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus atrogularis,Black-throated Thrush,svarthalsad trast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus naumanni,Naumann's Thrush,rödtrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus eunomus,Dusky Thrush,bruntrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus pilaris,Fieldfare,björktrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus iliacus,Redwing,rödvingetrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus philomelos,Song Thrush,taltrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus viscivorus,Mistle Thrush,dubbeltrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Turdus migratorius,American Robin,vandringstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,TÄTTINGAR
-Muscicapa striata,Spotted Flycatcher,grå flugsnappare,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Muscicapa dauurica,Asian Brown Flycatcher,glasögonflugsnappare,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Erithacus rubecula,European Robin,rödhake,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Luscinia svecica,Bluethroat,blåhake,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Luscinia luscinia,Thrush Nightingale,näktergal,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Luscinia megarhynchos,Common Nightingale,sydnäktergal,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Irania gutturalis,White-throated Robin,vitstrupig näktergal,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Calliope calliope,Siberian Rubythroat,rubinnäktergal,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Tarsiger cyanurus,Red-flanked Bluetail,tajgablåstjärt,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Ficedula albicilla,Taiga Flycatcher,tajgaflugsnappare,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Ficedula parva,Red-breasted Flycatcher,mindre flugsnappare,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Ficedula hypoleuca,European Pied Flycatcher,svartvit flugsnappare,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Ficedula albicollis,Collared Flycatcher,halsbandsflugsnappare,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Phoenicurus ochruros,Black Redstart,svart rödstjärt,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Phoenicurus phoenicurus,Common Redstart,rödstjärt,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Phoenicurus auroreus,Daurian Redstart,svartryggig rödstjärt,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Monticola saxatilis,Common Rock Thrush,stentrast,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Monticola solitarius,Blue Rock Thrush,blåtrast,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Saxicola rubetra,Whinchat,buskskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Saxicola rubicola,European Stonechat,svarthakad buskskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Saxicola maurus,Siberian Stonechat,vitgumpad buskskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Saxicola stejnegeri,Stejneger's Stonechat,amurbuskskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Saxicola caprata,Pied Bush Chat,svart buskskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Oenanthe oenanthe,Northern Wheatear,stenskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Oenanthe isabellina,Isabelline Wheatear,isabellastenskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Oenanthe deserti,Desert Wheatear,ökenstenskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Oenanthe hispanica,Western Black-eared Wheatear,västlig medelhavsstenskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Oenanthe melanoleuca,Eastern Black-eared Wheatear,östlig medelhavsstenskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Oenanthe pleschanka,Pied Wheatear,nunnestenskvätta,Muscicapidae,"Chats, Old World Flycatchers",Flugsnappare,PASSERIFORMES,TÄTTINGAR
-Cinclus cinclus,White-throated Dipper,strömstare,Cinclidae,Dippers,Strömstarar,PASSERIFORMES,TÄTTINGAR
-Passer domesticus,House Sparrow,gråsparv,Passeridae,Old World Sparrows,Sparvfinkar,PASSERIFORMES,TÄTTINGAR
-Passer hispaniolensis,Spanish Sparrow,spansk sparv,Passeridae,Old World Sparrows,Sparvfinkar,PASSERIFORMES,TÄTTINGAR
-Passer montanus,Eurasian Tree Sparrow,pilfink,Passeridae,Old World Sparrows,Sparvfinkar,PASSERIFORMES,TÄTTINGAR
-Prunella collaris,Alpine Accentor,alpjärnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,TÄTTINGAR
-Prunella montanella,Siberian Accentor,sibirisk järnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,TÄTTINGAR
-Prunella atrogularis,Black-throated Accentor,svartstrupig järnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,TÄTTINGAR
-Prunella modularis,Dunnock,järnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,TÄTTINGAR
-Motacilla flava,Yellow Wagtail,gulärla,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Motacilla citreola,Citrine Wagtail,citronärla,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Motacilla cinerea,Grey Wagtail,forsärla,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Motacilla alba,White Wagtail,sädesärla,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus richardi ,Richard's Pipit,större piplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus godlewskii,Blyth's Pipit,mongolpiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus campestris,Tawny Pipit,fältpiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus pratensis,Meadow Pipit,ängspiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus trivialis,Tree Pipit,trädpiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus hodgsoni,Olive-backed Pipit,sibirisk piplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus gustavi,Pechora Pipit,tundrapiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus cervinus,Red-throated Pipit,rödstrupig piplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus rubescens,Buff-bellied Pipit,hedpiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus spinoletta,Water Pipit,vattenpiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Anthus petrosus,Eurasian Rock Pipit,skärpiplärka,Motacillidae,"Wagtails, Pipits",Ärlor,PASSERIFORMES,TÄTTINGAR
-Fringilla coelebs,Common Chaffinch,bofink,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Fringilla montifringilla,Brambling,bergfink,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Coccothraustes coccothraustes,Hawfinch,stenknäck,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Pinicola enucleator,Pine Grosbeak,tallbit,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Pyrrhula pyrrhula,Eurasian Bullfinch,domherre,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Bucanetes githagineus,Trumpeter Finch,ökentrumpetare,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Carpodacus erythrinus,Common Rosefinch,rosenfink,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Carpodacus sibiricus,Long-tailed Rosefinch,långstjärtad rosenfink,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Carpodacus roseus,Pallas's Rosefinch,sibirisk rosenfink,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Chloris chloris,European Greenfinch,grönfink,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Linaria flavirostris,Twite,vinterhämpling,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Linaria cannabina,Common Linnet,hämpling,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Acanthis flammea,Redpoll,gråsiska,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Loxia pytyopsittacus,Parrot Crossbill,större korsnäbb,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Loxia curvirostra,Red Crossbill,mindre korsnäbb,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Loxia bifasciata,Two-barred Crossbill,bändelkorsnäbb,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Carduelis carduelis,European Goldfinch,steglits,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Serinus serinus,European Serin,gulhämpling,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Spinus spinus,Eurasian Siskin,grönsiska,Fringillidae,Finches,Finkar,PASSERIFORMES,TÄTTINGAR
-Calcarius lapponicus,Lapland Longspur,lappsparv,Calcariidae,"Longspurs, Snow Buntings",Sporrsparvar,PASSERIFORMES,TÄTTINGAR
-Plectrophenax nivalis,Snow Bunting,snösparv,Calcariidae,"Longspurs, Snow Buntings",Sporrsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza calandra,Corn Bunting,kornsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza citrinella,Yellowhammer,gulsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza leucocephalos,Pine Bunting,tallsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza cia,Rock Bunting,klippsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza buchanani,Grey-necked Bunting,bergortolan,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza cineracea,Cinereous Bunting,gulgrå sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza hortulana,Ortolan Bunting,ortolansparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza caesia,Cretzschmar's Bunting,rostsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza cirlus,Cirl Bunting,häcksparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza fucata,Chestnut-eared Bunting,rödkindad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza pusilla,Little Bunting,dvärgsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza chrysophrys,Yellow-browed Bunting,gulbrynad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza rustica,Rustic Bunting,videsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza aureola,Yellow-breasted Bunting,gyllensparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza melanocephala,Black-headed Bunting,svarthuvad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza bruniceps,Red-headed Bunting,stäppsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza spodocephala,Black-faced Bunting,gråhuvad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza pallasi,Pallas's Reed Bunting,dvärgsävsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Emberiza schoeniclus,Common Reed Bunting,sävsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,TÄTTINGAR
-Spizelloides arborea,American Tree Sparrow,tundrasparv,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,TÄTTINGAR
-Junco hyemalis,Dark-eyed Junco,mörkögd junco,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,TÄTTINGAR
-Zonotrichia albicollis,White-throated Sparrow,vitstrupig sparv,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,TÄTTINGAR
-Melospiza melodia,Song Sparrow,sångsparv,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,TÄTTINGAR
-Xanthocephalus xanthocephalus,Yellow-headed Blackbird,gulhuvad ängstrupial,Icteridae,"Oropendulas, Orioles",Trupialer,PASSERIFORMES,TÄTTINGAR
-Pheucticus ludovicianus,Rose-breasted Grosbeak,brokig kardinal,Cardinalidae,"Cardinals, Grosbeaks",Kardinaler,PASSERIFORMES,TÄTTINGAR
-Passerina cyanea,Indigo Bunting,turkoskardinal,Cardinalidae,"Cardinals, Grosbeaks",Kardinaler,PASSERIFORMES,TÄTTINGAR
+bird_scientific,bird_english,bird_swedish,family_scientific,family_english,family_swedish,order_scientific,order_english,order_swedish
+Branta bernicla,Brant Goose,prutgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Branta ruficollis,Red-breasted Goose,rödhalsad gås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Branta canadensis,Canada Goose,kanadagås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Branta leucopsis,Barnacle Goose,vitkindad gås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser rossii,Ross's Goose,dvärgsnögås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser caerulescens,Snow Goose,snögås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser anser,Greylag Goose,grågås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser fabalis,Bean Goose,sädgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser brachyrhynchus,Pink-footed Goose,spetsbergsgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser albifrons,Greater White-fronted Goose,bläsgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anser erythropus,Lesser White-fronted Goose,fjällgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Cygnus olor,Mute Swan,knölsvan,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Cygnus columbianus,Tundra Swan,mindre sångsvan,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Cygnus cygnus,Whooper Swan,sångsvan,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Alopochen aegyptiaca,Egyptian Goose,nilgås,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Tadorna tadorna,Common Shelduck,gravand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Tadorna ferruginea,Ruddy Shelduck,rostand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas formosa,Baikal Teal,gulkindad kricka,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas querquedula,Garganey,årta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas discors,Blue-winged Teal,blåvingad årta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas clypeata,Northern Shoveler,skedand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas strepera,Gadwall,snatterand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas falcata,Falcated Duck,praktand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas penelope,Eurasian Wigeon,bläsand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas americana,American Wigeon,amerikansk bläsand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas platyrhynchos,Mallard,gräsand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas rubripes,American Black Duck,svartand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas acuta,Northern Pintail,stjärtand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas crecca,Eurasian Teal,kricka,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Anas carolinensis,Green-winged Teal,amerikansk kricka,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Netta rufina,Red-crested Pochard,rödhuvad dykand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Aythya ferina,Common Pochard,brunand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Aythya nyroca,Ferruginous Duck,vitögd dykand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Aythya collaris,Ring-necked Duck,ringand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Aythya fuligula,Tufted Duck,vigg,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Aythya marila,Greater Scaup,bergand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Aythya affinis,Lesser Scaup,mindre bergand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Polysticta stelleri,Steller's Eider,alförrädare,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Somateria spectabilis,King Eider,praktejder,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Somateria mollissima,Common Eider,ejder,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Histrionicus histrionicus,Harlequin Duck,strömand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Melanitta perspicillata,Surf Scoter,vitnackad svärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Melanitta fusca,Velvet Scoter,svärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Melanitta deglandi,White-winged Scoter,amerikansk knölsvärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Melanitta stejnegeri,Stejneger's Scoter,sibirisk knölsvärta,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Melanitta nigra,Common Scoter,sjöorre,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Melanitta americana,Black Scoter,amerikansk sjöorre,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Clangula hyemalis,Long-tailed Duck,alfågel,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Bucephala albeola,Bufflehead,buffelhuvud,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Bucephala clangula,Common Goldeneye,knipa,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Mergellus albellus,Smew,salskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Lophodytes cucullatus,Hooded Merganser,kamskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Mergus merganser,Common Merganser,storskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Mergus serrator,Red-breasted Merganser,småskrake,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Oxyura jamaicensis,Ruddy Duck,amerikansk kopparand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Oxyura leucocephala,White-headed Duck,kopparand,Anatidae,"Ducks, Geese and Swans",Änder,ANSERIFORMES,"Waterfowl: Ducks, Geese and Swans",ANDFÅGLAR
+Tetrastes bonasia,Hazel Grouse,järpe,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Tetrao urogallus,Western Capercaillie,tjäder,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Lyrurus tetrix,Black Grouse,orre,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Lagopus muta,Rock Ptarmigan,fjällripa,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Lagopus lagopus,Willow Ptarmigan,dalripa,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Perdix perdix,Grey Partridge,rapphöna,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Coturnix coturnix,Common Quail,vaktel,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Phasianus colchicus,Common Pheasant,fasan,Phasianidae,Pheasants and allies,Fasanfåglar,GALLIFORMES,"Landfowl: Grouse, Quail and Pheasants",HÖNSFÅGLAR
+Caprimulgus europaeus,European Nightjar,nattskärra,Caprimulgidae,Nightjars,Nattskärror,CAPRIMULGIFORMES,Nightjars,SKÄRRFÅGLAR
+Caprimulgus aegyptius,Egyptian Nightjar,ökennattskärra,Caprimulgidae,Nightjars,Nattskärror,CAPRIMULGIFORMES,Nightjars,SKÄRRFÅGLAR
+Hirundapus caudacutus,White-throated Needletail,taggstjärtseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Chaetura pelagica,Chimney Swift,skorstensseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Apus melba,Alpine Swift,alpseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Apus apus,Common Swift,tornseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Apus pallidus,Pallid Swift,blek tornseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Apus pacificus,Pacific Swift,orientseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Apus affinis,Little Swift,stubbstjärtseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Apus caffer,White-rumped Swift,vitgumpseglare,Apodidae,Swifts,Seglare,APODIFORMES,Swifts,SEGLAR- OCH KOLIBRIFÅGLAR
+Otis tarda,Great Bustard,stortrapp,Otididae,Bustards,Trappar,OTIDIFORMES,Bustards,TRAPPFÅGLAR
+Chlamydotis macqueenii,Macqueen's Bustard,kragtrapp,Otididae,Bustards,Trappar,OTIDIFORMES,Bustards,TRAPPFÅGLAR
+Tetrax tetrax,Little Bustard,småtrapp,Otididae,Bustards,Trappar,OTIDIFORMES,Bustards,TRAPPFÅGLAR
+Clamator glandarius,Great Spotted Cuckoo,skatgök,Cuculidae,Cuckoos,Gökar,CUCULIFORMES,Cuckoos,GÖKFÅGLAR
+Cuculus canorus,Common Cuckoo,gök,Cuculidae,Cuckoos,Gökar,CUCULIFORMES,Cuckoos,GÖKFÅGLAR
+Syrrhaptes paradoxus,Pallas's Sandgrouse,stäppflyghöna,Pteroclidae,Sandgrouse,Flyghöns,PTEROCLIFORMES,Sandgrouses,FLYGHÖNSFÅGLAR
+Columba livia,Rock Dove / Feral Pigeon,klippduva / tamduva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Columba oenas,Stock Dove,skogsduva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Columba palumbus,Common Wood Pigeon,ringduva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Streptopelia turtur,European Turtle Dove,turturduva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Streptopelia orientalis,Oriental Turtle Dove,större turturduva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Streptopelia decaocto,Eurasian Collared Dove,turkduva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Zenaida macroura,Mourning Dove,spetsstjärtad duva,Columbidae,Pigeons and Doves,Duvor,COLUMBIFORMES,Pigeons and Doves,DUVFÅGLAR
+Rallus aquaticus,Water Rail,vattenrall,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Crex crex,Corn Crake,kornknarr,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Porzana carolina,Sora,karolinasumphöna,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Porzana porzana,Spotted Crake,småfläckig sumphöna,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Gallinula chloropus,Common Moorhen,rörhöna,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Fulica atra,Eurasian Coot,sothöna,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Zapornia pusilla,Baillon's Crake,dvärgsumphöna,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Zapornia parva,Little Crake,mindre sumphöna,Rallidae,Rails Crakes and Coots,Rallar,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Grus canadensis,Sandhill Crane,prärietrana,Gruidae,Cranes,Tranor,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Grus virgo,Demoiselle Crane,jungfrutrana,Gruidae,Cranes,Tranor,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Grus grus,Common Crane,trana,Gruidae,Cranes,Tranor,GRUIFORMES,"Marshbirds: Rails, Crakes, Coots and Cranes",TRANFÅGLAR
+Tachybaptus ruficollis,Little Grebe,smådopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,Grebes,DOPPINGFÅGLAR
+Podiceps grisegena,Red-necked Grebe,gråhakedopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,Grebes,DOPPINGFÅGLAR
+Podiceps cristatus,Great Crested Grebe,skäggdopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,Grebes,DOPPINGFÅGLAR
+Podiceps auritus,Horned Grebe,svarthakedopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,Grebes,DOPPINGFÅGLAR
+Podiceps nigricollis,Black-necked Grebe,svarthalsad dopping,Podicipedidae,Grebes,Doppingar,PODICIPEDIFORMES,Grebes,DOPPINGFÅGLAR
+Phoenicopterus roseus,Greater Flamingo,större flamingo,Phoenicopteridae,Flamingos,Flamingor,PHOENICOPTERIFORMES,Flamingos,FLAMINGOFÅGLAR
+Burhinus oedicnemus,Eurasian Stone-curlew,tjockfot,Burhinidae,Stone-curlews,Tjockfotar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Haematopus ostralegus,Eurasian Oystercatcher,strandskata,Haematopodidae,Oystercatchers,Strandskator,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Himantopus himantopus,Black-winged Stilt,styltlöpare,Recurvirostridae,Stilts and Avocets,Skärfläckor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Recurvirostra avosetta,Pied Avocet,skärfläcka,Recurvirostridae,Stilts and Avocets,Skärfläckor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Vanellus vanellus,Northern Lapwing,tofsvipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Vanellus cinereus,Grey-headed Lapwing,gråhuvad vipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Vanellus gregarius,Sociable Lapwing,stäppvipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Vanellus leucurus,White-tailed Lapwing,sumpvipa,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Pluvialis apricaria,European Golden Plover,ljungpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Pluvialis fulva,Pacific Golden Plover,sibirisk tundrapipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Pluvialis dominica,American Golden Plover,amerikansk tundrapipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Pluvialis squatarola,Grey Plover,kustpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius hiaticula,Common Ringed Plover,större strandpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius dubius,Little Ringed Plover,mindre strandpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius alexandrinus,Kentish Plover,svartbent strandpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius mongolus,Lesser Sand Plover,mongolpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius leschenaultii,Greater Sand Plover,ökenpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius asiaticus,Caspian Plover,kaspisk pipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Charadrius morinellus,Eurasian Dotterel,fjällpipare,Charadriidae,Plovers,Pipare,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Bartramia longicauda,Upland Sandpiper,piparsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Numenius phaeopus,Eurasian Whimbrel,småspov,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Numenius minutus,Little Curlew,dvärgspov,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Numenius arquata,Eurasian Curlew,storspov,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Limosa lapponica,Bar-tailed Godwit,myrspov,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Limosa limosa,Black-tailed Godwit,rödspov,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Limosa haemastica,Hudsonian Godwit,hudsonspov,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Arenaria interpres,Ruddy Turnstone,roskarl,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris tenuirostris,Great Knot,kolymasnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris canutus,Red Knot,kustsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris pugnax,Ruff,brushane,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris falcinellus,Broad-billed Sandpiper,myrsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris acuminata,Sharp-tailed Sandpiper,spetsstjärtad snäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris himantopus,Stilt Sandpiper,styltsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris ferruginea,Curlew Sandpiper,spovsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris temminckii,Temminck's Stint,mosnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris subminuta,Long-toed Stint,långtåsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris ruficollis,Red-necked Stint,rödhalsad snäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris alba,Sanderling,sandlöpare,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris alpina,Dunlin,kärrsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris maritima,Purple Sandpiper,skärsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris bairdii,Baird's Sandpiper,gulbröstad snäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris minuta,Little Stint,småsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris fuscicollis,White-rumped Sandpiper,vitgumpsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris subruficollis,Buff-breasted Sandpiper,prärielöpare,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris melanotos,Pectoral Sandpiper,tuvsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris pusilla,Semipalmated Sandpiper,sandsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Calidris mauri,Western Sandpiper,tundrasnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Limnodromus scolopaceus,Long-billed Dowitcher,större beckasinsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Limnodromus griseus,Short-billed Dowitcher,mindre beckasinsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Scolopax rusticola,Eurasian Woodcock,morkulla,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Lymnocryptes minimus,Jack Snipe,dvärgbeckasin,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Gallinago media,Great Snipe,dubbelbeckasin,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Gallinago gallinago,Common Snipe,enkelbeckasin,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Gallinago delicata,Wilson's Snipe,wilsonbeckasin,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Xenus cinereus,Terek Sandpiper,tereksnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Phalaropus tricolor,Wilson's Phalarope,wilsonsimsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Phalaropus lobatus,Red-necked Phalarope,smalnäbbad simsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Phalaropus fulicarius,Red Phalarope,brednäbbad simsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Actitis hypoleucos,Common Sandpiper,drillsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Actitis macularius,Spotted Sandpiper,fläckdrillsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa ochropus,Green Sandpiper,skogssnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa solitaria,Solitary Sandpiper,amerikansk skogssnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa brevipes,Grey-tailed Tattler,sibirisk gråsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa flavipes,Lesser Yellowlegs,mindre gulbena,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa totanus,Common Redshank,rödbena,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa stagnatilis,Marsh Sandpiper,dammsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa glareola,Wood Sandpiper,grönbena,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa erythropus,Spotted Redshank,svartsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa nebularia,Common Greenshank,gluttsnäppa,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Tringa melanoleuca,Greater Yellowlegs,större gulbena,Scolopacidae,Sandpipers and Snipes,Snäppor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Cursorius cursor,Cream-colored Courser,ökenlöpare,Glareolidae,Coursers and Pratincoles,Vadarsvalor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Glareola pratincola,Collared Pratincole,rödvingad vadarsvala,Glareolidae,Coursers and Pratincoles,Vadarsvalor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Glareola maldivarum,Oriental Pratincole,orientvadarsvala,Glareolidae,Coursers and Pratincoles,Vadarsvalor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Glareola nordmanni,Black-winged Pratincole,svartvingad vadarsvala,Glareolidae,Coursers and Pratincoles,Vadarsvalor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Rissa tridactyla,Black-legged Kittiwake,tretåig mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Pagophila eburnea,Ivory Gull,ismås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Xema sabini,Sabine's Gull,tärnmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Chroicocephalus genei,Slender-billed Gull,långnäbbad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Chroicocephalus philadelphia,Bonaparte's Gull,trädmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Chroicocephalus ridibundus,Black-headed Gull,skrattmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Hydrocoloeus minutus,Little Gull,dvärgmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Rhodostethia rosea,Ross's Gull,rosenmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Leucophaeus atricilla,Laughing Gull,sotvingad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Leucophaeus pipixcan,Franklin's Gull,präriemås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Ichthyaetus melanocephalus,Mediterranean Gull,svarthuvad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Ichthyaetus ichthyaetus,Pallas's Gull,svarthuvad trut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus canus,Mew Gull,fiskmås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus delawarensis,Ring-billed Gull,ringnäbbad mås,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus marinus,Great Black-backed Gull,havstrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus hyperboreus,Glaucous Gull,vittrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus glaucoides,Iceland Gull,vitvingad trut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus argentatus,Herring Gull,gråtrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus cachinnans,Caspian Gull,kaspisk trut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus michahellis,Yellow-legged Gull,medelhavstrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Larus fuscus,Lesser Black-backed Gull,silltrut,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Gelochelidon nilotica,Gull-billed Tern,sandtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Hydroprogne caspia,Caspian Tern,skräntärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Thalasseus sandvicensis,Sandwich Tern,kentsk tärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Sternula albifrons,Little Tern,småtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Onychoprion anaethetus,Bridled Tern,tygeltärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Onychoprion fuscatus,Sooty Tern,sottärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Sterna dougallii,Roseate Tern,rosentärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Sterna hirundo,Common Tern,fisktärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Sterna paradisaea,Arctic Tern,silvertärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Sterna forsteri,Forster's Tern,kärrtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Chlidonias hybrida,Whiskered Tern,skäggtärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Chlidonias leucopterus,White-winged Tern,vitvingad tärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Chlidonias niger,Black Tern,svarttärna,Laridae,"Gulls, Terns and Skimmers",Måsfåglar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Stercorarius skua,Great Skua,storlabb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Stercorarius pomarinus,Pomarine Jaeger,bredstjärtad labb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Stercorarius parasiticus,Parasitic Jaeger,kustlabb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Stercorarius longicaudus,Long-tailed Jaeger,fjällabb,Stercorariidae,Skuas,Labbar,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Alle alle,Little Auk,alkekung,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Uria lomvia,Thick-billed Murre,spetsbergsgrissla,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Uria aalge,Common Murre,sillgrissla,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Alca torda,Razorbill,tordmule,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Pinguinus impennis,Great Auk,garfågel,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Cepphus grylle,Black Guillemot,tobisgrissla,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Aethia psittacula,Parakeet Auklet,papegojalka,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Fratercula arctica,Atlantic Puffin,lunnefågel,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Fratercula cirrhata,Tufted Puffin,tofslunne,Alcidae,Auks,Alkor,CHARADRIIFORMES,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks",VADARFÅGLAR
+Gavia stellata,Red-throated Loon,smålom,Gaviidae,Loons,Lommar,GAVIIFORMES,Loons,LOMFÅGLAR
+Gavia arctica,Black-throated Loon,storlom,Gaviidae,Loons,Lommar,GAVIIFORMES,Loons,LOMFÅGLAR
+Gavia pacifica,Pacific Loon,stillahavslom,Gaviidae,Loons,Lommar,GAVIIFORMES,Loons,LOMFÅGLAR
+Gavia immer,Common Loon,svartnäbbad islom,Gaviidae,Loons,Lommar,GAVIIFORMES,Loons,LOMFÅGLAR
+Gavia adamsii,Yellow-billed Loon,vitnäbbad islom,Gaviidae,Loons,Lommar,GAVIIFORMES,Loons,LOMFÅGLAR
+Thalassarche melanophris,Black-browed Albatross,svartbrynad albatross,Diomedeidae,Albatrosses,Albatrosser,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Thalassarche chlororhynchos,Yellow-nosed Albatross,mindre albatross,Diomedeidae,Albatrosses,Albatrosser,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Hydrobates pelagicus,European Storm Petrel,stormsvala,Hydrobatidae,Northern Storm Petrels,Nordstormsvalor,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Oceanodroma leucorhoa,Leach's Storm Petrel,klykstjärtad stormsvala,Hydrobatidae,Northern Storm Petrels,Nordstormsvalor,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Fulmarus glacialis,Northern Fulmar,stormfågel,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Pterodroma feae/madeira,Fea's Petrel/Zino's Petrel,atlantpetrell/madeirapetrell,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Calonectris borealis/diomedea,Cory's/Scopoli's Shearwater,gulnäbbad lira/scopolilira,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Ardenna grisea,Sooty Shearwater,grålira,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Ardenna gravis,Great Shearwater,större lira,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Puffinus puffinus,Manx Shearwater,mindre lira,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Puffinus mauretanicus,Balearic Shearwater,balearisk lira,Procellariidae,Petrels and Shearwaters,Liror,PROCELLARIIFORMES,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses",STORMFÅGLAR
+Ciconia nigra,Black Stork,svart stork,Ciconiidae,Storks,Storkar,CICONIIFORMES,Storks,STORKFÅGLAR
+Ciconia ciconia,White Stork,vit stork,Ciconiidae,Storks,Storkar,CICONIIFORMES,Storks,STORKFÅGLAR
+Fregata magnificens,Magnificent Frigatebird,praktfregattfågel,Fregatidae,Frigatebirds,Fregattfåglar,SULIFORMES,"Cormorants, Shags and Frigatebirds",SULFÅGLAR
+Morus bassanus,Northern Gannet,havssula,Sulidae,Gannets,Sulor,SULIFORMES,"Cormorants, Shags and Frigatebirds",SULFÅGLAR
+Microcarbo pygmaeus,Pygmy Cormorant,dvärgskarv,Phalacrocoracidae,Cormorants and Shags,Skarvar,SULIFORMES,"Cormorants, Shags and Frigatebirds",SULFÅGLAR
+Phalacrocorax carbo,Great Cormorant,storskarv,Phalacrocoracidae,Cormorants and Shags,Skarvar,SULIFORMES,"Cormorants, Shags and Frigatebirds",SULFÅGLAR
+Phalacrocorax aristotelis,European Shag,toppskarv,Phalacrocoracidae,Cormorants and Shags,Skarvar,SULIFORMES,"Cormorants, Shags and Frigatebirds",SULFÅGLAR
+Plegadis falcinellus,Glossy Ibis,bronsibis,Threskiornithidae,Ibises and Spoonbills,Ibisar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Platalea leucorodia,Eurasian Spoonbill,skedstork,Threskiornithidae,Ibises and Spoonbills,Ibisar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Botaurus stellaris,Eurasian Bittern,rördrom,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Botaurus lentiginosus,American Bittern,amerikansk rördrom,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Ixobrychus minutus,Little Bittern,dvärgrördrom,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Nycticorax nycticorax,Black-crowned Night Heron,natthäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Ardeola ralloides,Squacco Heron,rallhäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Bubulcus ibis,Cattle Egret,kohäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Ardea cinerea,Grey Heron,gråhäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Ardea purpurea,Purple Heron,purpurhäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Ardea alba,Great Egret,ägretthäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Egretta garzetta,Little Egret,silkeshäger,Ardeidae,Herons and Bitterns,Hägrar,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Pelecanus onocrotalus,Great White Pelican,vit pelikan,Pelecanidae,Pelicans,Pelikaner,PELECANIFORMES,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns",PELIKANFÅGLAR
+Pandion haliaetus,Osprey,fiskgjuse,Pandionidae,Ospreys,Fiskgjusar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Elanus caeruleus,Black-winged Kite,svartvingad glada,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Neophron percnopterus,Egyptian Vulture,smutsgam,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Pernis apivorus,European Honey Buzzard,bivråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Gyps fulvus,Griffon Vulture,gåsgam,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Aegypius monachus,Cinereous Vulture,grågam,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Circaetus gallicus,Short-toed Snake Eagle,ormörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Clanga pomarina,Lesser Spotted Eagle,mindre skrikörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Clanga clanga,Greater Spotted Eagle,större skrikörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Hieraaetus pennatus,Booted Eagle,dvärgörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Aquila nipalensis,Steppe Eagle,stäppörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Aquila heliaca,Eastern Imperial Eagle,kejsarörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Aquila chrysaetos,Golden Eagle,kungsörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Accipiter nisus,Eurasian Sparrowhawk,sparvhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Accipiter gentilis,Northern Goshawk,duvhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Circus aeruginosus,Western Marsh Harrier,brun kärrhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Circus cyaneus,Hen Harrier,blå kärrhök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Circus macrourus,Pallid Harrier,stäpphök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Circus pygargus,Montagu's Harrier,ängshök,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Milvus milvus,Red Kite,röd glada,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Milvus migrans,Black Kite,brun glada,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Haliaeetus albicilla,White-tailed Eagle,havsörn,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Buteo lagopus,Rough-legged Buzzard,fjällvråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Buteo rufinus,Long-legged Buzzard,örnvråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Buteo buteo,Common Buzzard,ormvråk,Accipitridae,"Kites, Hawks and Eagles",Hökartade rovfåglar,ACCIPITRIFORMES,Raptors,HÖKFÅGLAR
+Tyto alba,Western Barn Owl,tornuggla,Tytonidae,Barn Owls,Tornugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Otus scops,Eurasian Scops Owl,dvärguv,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Bubo scandiacus,Snowy Owl,fjälluggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Bubo bubo,Eurasian Eagle-Owl,berguv,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Strix aluco,Tawny Owl,kattuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Strix uralensis,Ural Owl,slaguggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Strix nebulosa,Great Grey Owl,lappuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Surnia ulula,Northern Hawk-Owl,hökuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Glaucidium passerinum,Eurasian Pygmy Owl,sparvuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Athene noctua,Little Owl,minervauggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Aegolius funereus,Boreal Owl,pärluggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Asio otus,Long-eared Owl,hornuggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Asio flammeus,Short-eared Owl,jorduggla,Strigidae,Owls,Ugglor,STRIGIFORMES,Owls,UGGLEFÅGLAR
+Upupa epops,Eurasian Hoopoe,härfågel,Upupidae,Hoopoes,Härfåglar,BUCEROTIFORMES,Hoopoes,HÄRFÅGLAR OCH NÄSHORNSFÅGLAR
+Coracias garrulus,European Roller,blåkråka,Coraciidae,Rollers,Blåkråkor,CORACIIFORMES,Kingfishers and allies: Rollers and Bee-eaters,PRAKTFÅGLAR
+Alcedo atthis,Common Kingfisher,kungsfiskare,Alcedinidae,Kingfishers,Kungsfiskare,CORACIIFORMES,Kingfishers and allies: Rollers and Bee-eaters,PRAKTFÅGLAR
+Merops persicus,Blue-cheeked Bee-eater,grön biätare,Meropidae,Bee-eaters,Biätare,CORACIIFORMES,Kingfishers and allies: Rollers and Bee-eaters,PRAKTFÅGLAR
+Merops apiaster,European Bee-eater,biätare,Meropidae,Bee-eaters,Biätare,CORACIIFORMES,Kingfishers and allies: Rollers and Bee-eaters,PRAKTFÅGLAR
+Jynx torquilla,Eurasian Wryneck,göktyta,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Picoides tridactylus,Eurasian Three-toed Woodpecker,tretåig hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Dendrocoptes medius,Middle Spotted Woodpecker,mellanspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Dryobates minor,Lesser Spotted Woodpecker,mindre hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Dendrocopos major,Great Spotted Woodpecker,större hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Dendrocopos leucotos,White-backed Woodpecker,vitryggig hackspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Dryocopus martius,Black Woodpecker,spillkråka,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Picus viridis,European Green Woodpecker,gröngöling,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Picus canus,Grey-headed Woodpecker,gråspett,Picidae,Woodpeckers,Hackspettar,PICIFORMES,Woodpeckers and allies,HACKSPETTARTADE FÅGLAR
+Falco naumanni,Lesser Kestrel,rödfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco tinnunculus,Common Kestrel,tornfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco vespertinus,Red-footed Falcon,aftonfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco amurensis,Amur Falcon,amurfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco eleonorae,Eleonora's Falcon,eleonorafalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco columbarius,Merlin,stenfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco subbuteo,Eurasian Hobby,lärkfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco cherrug,Saker Falcon,tatarfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco rusticolus,Gyrfalcon,jaktfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Falco peregrinus,Peregrine Falcon,pilgrimsfalk,Falconidae,Falcons,Falkar,FALCONIFORMES,Falcons,FALKFÅGLAR
+Lanius cristatus,Brown Shrike,brun törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius collurio,Red-backed Shrike,törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius isabellinus,Isabelline Shrike,isabellatörnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius phoenicuroides,Red-tailed Shrike,turkestantörnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius schach,Long-tailed Shrike,rostgumpad törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius minor,Lesser Grey Shrike,svartpannad törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius excubitor,Great Grey Shrike,varfågel,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius elegans,Southern Grey Shrike,ökenvarfågel,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius senator,Woodchat Shrike,rödhuvad törnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lanius nubicus,Masked Shrike,masktörnskata,Laniidae,Shrikes,Törnskator,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oriolus oriolus,Eurasian Golden Oriole,sommargylling,Oriolidae,Orioles,Gyllingar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Perisoreus infaustus,Siberian Jay,lavskrika,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Garrulus glandarius,Eurasian Jay,nötskrika,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Pica pica,Eurasian Magpie,skata,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Nucifraga caryocatactes,Spotted Nutcracker,nötkråka,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Pyrrhocorax graculus,Alpine Chough,alpkaja,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Corvus monedula,Western Jackdaw,kaja,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Corvus dauuricus,Daurian Jackdaw,klippkaja,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Corvus frugilegus,Rook,råka,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Corvus corone,Carrion Crow,kråka,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Corvus corax,Northern Raven,korp,Corvidae,Crows and Jays,Kråkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Bombycilla garrulus,Bohemian Waxwing,sidensvans,Bombycillidae,Waxwings,Sidensvansar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Periparus ater,Coal Tit,svartmes,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lophophanes cristatus,European Crested Tit,tofsmes,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Poecile cinctus,Grey-headed Chickadee,lappmes,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Poecile palustris,Marsh Tit,entita,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Poecile montanus,Willow Tit,talltita,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Cyanistes caeruleus,Eurasian Blue Tit,blåmes,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Cyanistes cyanus,Azure Tit,azurmes,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Parus major,Great Tit,talgoxe,Paridae,Tits,Mesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Remiz pendulinus,Eurasian Penduline Tit,pungmes,Remizidae,Penduline Tits,Pungmesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Panurus biarmicus,Bearded Reedling,skäggmes,Panuridae,Bearded Reedling,Skäggmesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Lullula arborea,Woodlark,trädlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Alauda leucoptera,White-winged Lark,vitvingad lärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Alauda arvensis,Eurasian Skylark,sånglärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Galerida cristata,Crested Lark,tofslärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Eremophila alpestris,Common Horned Lark,berglärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Calandrella brachydactyla,Greater Short-toed Lark,korttålärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Melanocorypha bimaculata,Bimaculated Lark,asiatisk kalanderlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Melanocorypha calandra,Calandra Lark,kalanderlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Melanocorypha yeltoniensis,Black Lark,svartlärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Alaudala rufescens,Lesser Short-toed Lark,dvärglärka,Alaudidae,Larks,Lärkor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Riparia riparia,Sand Martin,backsvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Hirundo rustica,Barn Swallow,ladusvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Ptyonoprogne rupestris,Eurasian Crag Martin,klippsvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Delichon urbicum,Common House Martin,hussvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Cecropis daurica,Red-rumped Swallow,rostgumpsvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Petrochelidon pyrrhonota,American Cliff Swallow,stensvala,Hirundinidae,Swallows,Svalor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Cettia cetti,Cetti's Warbler,cettisångare,Cettiidae,Cettia Bush Warblers,Cettisångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Aegithalos caudatus,Long-tailed Tit,stjärtmes,Aegithalidae,Bushtits,Stjärtmesar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus sibilatrix,Wood Warbler,grönsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus bonelli,Western Bonelli's Warbler,bergsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus orientalis,Eastern Bonelli's Warbler,balkansångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus humei,Hume's Leaf Warbler,bergtajgasångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus inornatus,Yellow-browed Warbler,tajgasångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus proregulus,Pallas's Leaf Warbler,kungsfågelsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus schwarzi,Radde's Warbler,videsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus fuscatus,Dusky Warbler,brunsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus neglectus,Plain Leaf Warbler,dvärgsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus trochilus,Willow Warbler,lövsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus collybita,Common Chiffchaff,gransångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus ibericus,Iberian Chiffchaff,iberisk gransångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus coronatus,Eastern Crowned Warbler,östlig kronsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus nitidus,Green Warbler,kaukasisk lundsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus plumbeitarsus,Two-barred Warbler,sibirisk lundsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus trochiloides,Greenish Warbler,lundsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phylloscopus borealis,Arctic Warbler,nordsångare,Phylloscopidae,Leaf Warblers and allies,Lövsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus arundinaceus,Great Reed Warbler,trastsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus paludicola,Aquatic Warbler,vattensångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus schoenobaenus,Sedge Warbler,sävsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus agricola,Paddyfield Warbler,fältsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus dumetorum,Blyth's Reed Warbler,busksångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus scirpaceus,Eurasian Reed Warbler,rörsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acrocephalus palustris,Marsh Warbler,kärrsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Iduna caligata,Booted Warbler,stäppsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Iduna rama,Sykes's Warbler,saxaulsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Iduna pallida,Eastern Olivaceous Warbler,eksångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Iduna opaca,Western Olivaceous Warbler,macchiasångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Hippolais polyglotta,Melodious Warbler,polyglottsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Hippolais icterina,Icterine Warbler,härmsångare,Acrocephalidae,Reed Warblers and allies,Rörsångare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Helopsaltes certhiola,Pallas's Grasshopper Warbler,starrsångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Locustella lanceolata,Lanceolated Warbler,träsksångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Locustella fluviatilis,River Warbler,flodsångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Locustella luscinioides,Savi's Warbler,vassångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Locustella naevia,Common Grasshopper Warbler,gräshoppsångare,Locustellidae,Grassbirds and allies,Gräsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Cisticola juncidis,Zitting Cisticola,grässångare,Cisticolidae,Cisticolas and allies,Cistikolor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Sylvia atricapilla,Eurasian Blackcap,svarthätta,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Sylvia borin,Garden Warbler,trädgårdssångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca nisoria,Barred Warbler,höksångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca curruca,Lesser Whitethroat,ärtsångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca nana,Asian Desert Warbler,ökensångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca melanocephala,Sardinian Warbler,sammetshätta,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca iberiae,Western Subalpine Warbler,rostsångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca subalpina,Moltoni's Warbler,moltonisångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca cantillans,Eastern Subalpine Warbler,rödstrupig sångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca communis,Common Whitethroat,törnsångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Curruca undata,Dartford Warbler,provencesångare,Sylviidae,Sylviid Babblers,Sylvior,PASSERIFORMES,Perching birds,TÄTTINGAR
+Regulus ignicapilla,Common Firecrest,brandkronad kungsfågel,Regulidae,Goldcrests and Kinglets,Kungsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Regulus regulus,Goldcrest,kungsfågel,Regulidae,Goldcrests and Kinglets,Kungsfåglar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Troglodytes troglodytes,Eurasian Wren,gärdsmyg,Troglodytidae,Wrens,Gärdsmygar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Sitta europaea,Eurasian Nuthatch,nötväcka,Sittidae,Nuthatches,Nötväckor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Certhia familiaris,Eurasian Treecreeper,trädkrypare,Certhiidae,Treecreepers,Trädkrypare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Certhia brachydactyla,Short-toed Treecreeper,trädgårdsträdkrypare,Certhiidae,Treecreepers,Trädkrypare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Pastor roseus,Rosy Starling,rosenstare,Sturnidae,Starlings,Starar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Sturnus vulgaris,Common Starling,stare,Sturnidae,Starlings,Starar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Geokichla sibirica,Siberian Thrush,sibirisk trast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Zoothera aurea,White's Thrush,guldtrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Catharus fuscescens,Veery,rostskogstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Catharus ustulatus,Swainson's Thrush,beigekindad skogstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Catharus guttatus,Hermit Thrush,eremitskogstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus torquatus,Ring Ouzel,ringtrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus merula,Common Blackbird,koltrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus obscurus,Eyebrowed Thrush,gråhalsad trast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus atrogularis,Black-throated Thrush,svarthalsad trast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus naumanni,Naumann's Thrush,rödtrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus eunomus,Dusky Thrush,bruntrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus pilaris,Fieldfare,björktrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus iliacus,Redwing,rödvingetrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus philomelos,Song Thrush,taltrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus viscivorus,Mistle Thrush,dubbeltrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Turdus migratorius,American Robin,vandringstrast,Turdidae,Thrushes,Trastar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Muscicapa striata,Spotted Flycatcher,grå flugsnappare,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Muscicapa dauurica,Asian Brown Flycatcher,glasögonflugsnappare,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Erithacus rubecula,European Robin,rödhake,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Luscinia svecica,Bluethroat,blåhake,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Luscinia luscinia,Thrush Nightingale,näktergal,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Luscinia megarhynchos,Common Nightingale,sydnäktergal,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Irania gutturalis,White-throated Robin,vitstrupig näktergal,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Calliope calliope,Siberian Rubythroat,rubinnäktergal,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Tarsiger cyanurus,Red-flanked Bluetail,tajgablåstjärt,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Ficedula albicilla,Taiga Flycatcher,tajgaflugsnappare,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Ficedula parva,Red-breasted Flycatcher,mindre flugsnappare,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Ficedula hypoleuca,European Pied Flycatcher,svartvit flugsnappare,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Ficedula albicollis,Collared Flycatcher,halsbandsflugsnappare,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phoenicurus ochruros,Black Redstart,svart rödstjärt,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phoenicurus phoenicurus,Common Redstart,rödstjärt,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Phoenicurus auroreus,Daurian Redstart,svartryggig rödstjärt,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Monticola saxatilis,Common Rock Thrush,stentrast,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Monticola solitarius,Blue Rock Thrush,blåtrast,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Saxicola rubetra,Whinchat,buskskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Saxicola rubicola,European Stonechat,svarthakad buskskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Saxicola maurus,Siberian Stonechat,vitgumpad buskskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Saxicola stejnegeri,Stejneger's Stonechat,amurbuskskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Saxicola caprata,Pied Bush Chat,svart buskskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oenanthe oenanthe,Northern Wheatear,stenskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oenanthe isabellina,Isabelline Wheatear,isabellastenskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oenanthe deserti,Desert Wheatear,ökenstenskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oenanthe hispanica,Western Black-eared Wheatear,västlig medelhavsstenskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oenanthe melanoleuca,Eastern Black-eared Wheatear,östlig medelhavsstenskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Oenanthe pleschanka,Pied Wheatear,nunnestenskvätta,Muscicapidae,Old World Flycatchers,Flugsnappare,PASSERIFORMES,Perching birds,TÄTTINGAR
+Cinclus cinclus,White-throated Dipper,strömstare,Cinclidae,Dippers,Strömstarar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Passer domesticus,House Sparrow,gråsparv,Passeridae,Old World Sparrows,Sparvfinkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Passer hispaniolensis,Spanish Sparrow,spansk sparv,Passeridae,Old World Sparrows,Sparvfinkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Passer montanus,Eurasian Tree Sparrow,pilfink,Passeridae,Old World Sparrows,Sparvfinkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Prunella collaris,Alpine Accentor,alpjärnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Prunella montanella,Siberian Accentor,sibirisk järnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Prunella atrogularis,Black-throated Accentor,svartstrupig järnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Prunella modularis,Dunnock,järnsparv,Prunellidae,Accentors,Järnsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Motacilla flava,Yellow Wagtail,gulärla,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Motacilla citreola,Citrine Wagtail,citronärla,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Motacilla cinerea,Grey Wagtail,forsärla,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Motacilla alba,White Wagtail,sädesärla,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus richardi ,Richard's Pipit,större piplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus godlewskii,Blyth's Pipit,mongolpiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus campestris,Tawny Pipit,fältpiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus pratensis,Meadow Pipit,ängspiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus trivialis,Tree Pipit,trädpiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus hodgsoni,Olive-backed Pipit,sibirisk piplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus gustavi,Pechora Pipit,tundrapiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus cervinus,Red-throated Pipit,rödstrupig piplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus rubescens,Buff-bellied Pipit,hedpiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus spinoletta,Water Pipit,vattenpiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Anthus petrosus,Eurasian Rock Pipit,skärpiplärka,Motacillidae,Wagtails and Pipits,Ärlor,PASSERIFORMES,Perching birds,TÄTTINGAR
+Fringilla coelebs,Common Chaffinch,bofink,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Fringilla montifringilla,Brambling,bergfink,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Coccothraustes coccothraustes,Hawfinch,stenknäck,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Pinicola enucleator,Pine Grosbeak,tallbit,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Pyrrhula pyrrhula,Eurasian Bullfinch,domherre,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Bucanetes githagineus,Trumpeter Finch,ökentrumpetare,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Carpodacus erythrinus,Common Rosefinch,rosenfink,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Carpodacus sibiricus,Long-tailed Rosefinch,långstjärtad rosenfink,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Carpodacus roseus,Pallas's Rosefinch,sibirisk rosenfink,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Chloris chloris,European Greenfinch,grönfink,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Linaria flavirostris,Twite,vinterhämpling,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Linaria cannabina,Common Linnet,hämpling,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Acanthis flammea,Redpoll,gråsiska,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Loxia pytyopsittacus,Parrot Crossbill,större korsnäbb,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Loxia curvirostra,Red Crossbill,mindre korsnäbb,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Loxia bifasciata,Two-barred Crossbill,bändelkorsnäbb,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Carduelis carduelis,European Goldfinch,steglits,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Serinus serinus,European Serin,gulhämpling,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Spinus spinus,Eurasian Siskin,grönsiska,Fringillidae,Finches,Finkar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Calcarius lapponicus,Lapland Longspur,lappsparv,Calcariidae,Longspurs and Snow Buntings,Sporrsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Plectrophenax nivalis,Snow Bunting,snösparv,Calcariidae,Longspurs and Snow Buntings,Sporrsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza calandra,Corn Bunting,kornsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza citrinella,Yellowhammer,gulsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza leucocephalos,Pine Bunting,tallsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza cia,Rock Bunting,klippsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza buchanani,Grey-necked Bunting,bergortolan,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza cineracea,Cinereous Bunting,gulgrå sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza hortulana,Ortolan Bunting,ortolansparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza caesia,Cretzschmar's Bunting,rostsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza cirlus,Cirl Bunting,häcksparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza fucata,Chestnut-eared Bunting,rödkindad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza pusilla,Little Bunting,dvärgsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza chrysophrys,Yellow-browed Bunting,gulbrynad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza rustica,Rustic Bunting,videsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza aureola,Yellow-breasted Bunting,gyllensparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza melanocephala,Black-headed Bunting,svarthuvad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza bruniceps,Red-headed Bunting,stäppsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza spodocephala,Black-faced Bunting,gråhuvad sparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza pallasi,Pallas's Reed Bunting,dvärgsävsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Emberiza schoeniclus,Common Reed Bunting,sävsparv,Emberizidae,Old World Buntings,Fältsparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Spizelloides arborea,American Tree Sparrow,tundrasparv,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Junco hyemalis,Dark-eyed Junco,mörkögd junco,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Zonotrichia albicollis,White-throated Sparrow,vitstrupig sparv,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Melospiza melodia,Song Sparrow,sångsparv,Passerellidae,New World Sparrows,Amerikanska sparvar,PASSERIFORMES,Perching birds,TÄTTINGAR
+Xanthocephalus xanthocephalus,Yellow-headed Blackbird,gulhuvad ängstrupial,Icteridae,New World blackbirds,Trupialer,PASSERIFORMES,Perching birds,TÄTTINGAR
+Pheucticus ludovicianus,Rose-breasted Grosbeak,brokig kardinal,Cardinalidae,Cardinals and Grosbeaks,Kardinaler,PASSERIFORMES,Perching birds,TÄTTINGAR
+Passerina cyanea,Indigo Bunting,turkoskardinal,Cardinalidae,Cardinals and Grosbeaks,Kardinaler,PASSERIFORMES,Perching birds,TÄTTINGAR

--- a/db/migrate/20210511070115_add_english_name_to_order.rb
+++ b/db/migrate/20210511070115_add_english_name_to_order.rb
@@ -1,0 +1,5 @@
+class AddEnglishNameToOrder < ActiveRecord::Migration[6.0]
+  def change
+    add_column :orders, :english_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_06_155212) do
+ActiveRecord::Schema.define(version: 2021_05_11_070115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2021_05_06_155212) do
     t.string "swedish_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "english_name"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,7 @@ def csv_to_models
     unless order&.scientific_name&.downcase == row[:order_scientific]&.downcase
       # we have to create the order
       order = Order.create!(scientific_name: row[:order_scientific].capitalize,
+                            english_name: row[:order_english],
                             swedish_name: row[:order_swedish].capitalize)
     end
 

--- a/lib/tasks/01-add_english_name_to_order/data.csv
+++ b/lib/tasks/01-add_english_name_to_order/data.csv
@@ -1,25 +1,25 @@
 order_scientific,order_english
-Anseriformes,"Waterfowl: Ducks, geese and swans"
-Galliformes,"Landfowl: Grouse, quail and pheasants"
+Anseriformes,"Waterfowl: Ducks, Geese and Swans"
+Galliformes,"Landfowl: Grouse, Quail and Pheasants"
 Caprimulgiformes,Nightjars
 Apodiformes,Swifts
 Otidiformes,Bustards
 Cuculiformes,Cuckoos
 Pterocliformes,Sandgrouse
-Columbiformes,Pigeons and doves
-Gruiformes,"Marshbirds: Rails, crakes, coots and cranes"
+Columbiformes,Pigeons and Doves
+Gruiformes,"Marshbirds: Rails, Crakes, Coots and Cranes"
 Podicipediformes,Grebes
 Phoenicopteriformes,Flamingos
-Charadriiformes,"Shorebirds: curlews, oystercatchers, stilts,  avocets, plovers, sandpipers, snipes, coursers, pratincoles, gulls, terns, skimmers, skuas and auks"
+Charadriiformes,"Shorebirds: Curlews, Oystercatchers, Stilts, Avocets, Plovers, Sandpipers, Snipes, Coursers, Pratincoles, Gulls, Terns, Skimmers, Skuas and Auks"
 Gaviiformes,Loons
-Procellariiformes,"Tube-nosed seabirds: petrels, storm petrels, shearwaters and albatrosses"
+Procellariiformes,"Tube-nosed seabirds: Petrels, Storm petrels, Shearwaters and Albatrosses"
 Ciconiiformes,Storks
-Suliformes,"Cormorants, shags and frigatebirds"
-Pelecaniformes,"Ibis, herons, pelicans, egrets, shoebill and bitterns"
+Suliformes,"Cormorants, Shags and Frigatebirds"
+Pelecaniformes,"Ibis, Herons, Pelicans, Egrets, Shoebill and Bitterns"
 Accipitriformes,Raptors
 Strigiformes,Owls
 Bucerotiformes,Hoopoes
-Coraciiformes,Kingfishers and allies: rollers and bee-eaters
+Coraciiformes,Kingfishers and allies: Rollers and Bee-eaters
 Piciformes,Woodpeckers and allies
 Falconiformes,Falcons
 Passeriformes,Perching birds

--- a/lib/tasks/01-add_english_name_to_order/data.csv
+++ b/lib/tasks/01-add_english_name_to_order/data.csv
@@ -1,0 +1,25 @@
+order_scientific,order_english
+Anseriformes,"Waterfowl: Ducks, geese and swans"
+Galliformes,"Landfowl: Grouse, quail and pheasants"
+Caprimulgiformes,Nightjars
+Apodiformes,Swifts
+Otidiformes,Bustards
+Cuculiformes,Cuckoos
+Pterocliformes,Sandgrouse
+Columbiformes,Pigeons and doves
+Gruiformes,"Marshbirds: Rails, crakes, coots and cranes"
+Podicipediformes,Grebes
+Phoenicopteriformes,Flamingos
+Charadriiformes,"Shorebirds: curlews, oystercatchers, stilts,  avocets, plovers, sandpipers, snipes, coursers, pratincoles, gulls, terns, skimmers, skuas and auks"
+Gaviiformes,Loons
+Procellariiformes,"Tube-nosed seabirds: petrels, storm petrels, shearwaters and albatrosses"
+Ciconiiformes,Storks
+Suliformes,"Cormorants, shags and frigatebirds"
+Pelecaniformes,"Ibis, herons, pelicans, egrets, shoebill and bitterns"
+Accipitriformes,Raptors
+Strigiformes,Owls
+Bucerotiformes,Hoopoes
+Coraciiformes,Kingfishers and allies: rollers and bee-eaters
+Piciformes,Woodpeckers and allies
+Falconiformes,Falcons
+Passeriformes,Perching birds

--- a/lib/tasks/01-add_english_name_to_order/orders.rake
+++ b/lib/tasks/01-add_english_name_to_order/orders.rake
@@ -1,0 +1,33 @@
+require 'csv'
+
+namespace :orders do
+  desc "Update fields"
+    task add_english_name: :environment do
+
+    csv_file_path = Rails.root.join('lib', 'tasks', '01-add_english_name_to_order', 'data.csv')
+    csv_options = { col_sep: ',', headers: :first_row, header_converters: :symbol }
+
+    order = nil
+    counter = 0
+
+    CSV.foreach(csv_file_path, csv_options) do |row|
+      order = nil
+    
+      order = Order.find_by(scientific_name: row[:order_scientific].capitalize)
+
+      if order
+        order.english_name = row[:order_english]
+
+        if order.save
+          counter += 1
+        else
+          puts "something went wrong when saving the order"
+        end
+      else
+        puts "couldnt find the order by scientific name: #{row[:order_scientific].capitalize}"
+      end
+    end
+
+    puts "#{counter} out of #{Order.count} orders now have an english name"
+  end  
+end


### PR DESCRIPTION
Order now has an english_name with validations. So Order and Family now have the same fields and validations.

Created a new rake task for orders to add this data to the db, this needs to be run on production. But also updated the seeds file to include this english_name so that future developers do not need to remember to run this task.

Updated the API index and orders show endpoints to include english_name.
Updated the group component to show english and swedish name for both orders and families.