### PR TITLE
Update/both languages readability

### DIFF
--- a/app/javascript/react_app/components/group.jsx
+++ b/app/javascript/react_app/components/group.jsx
@@ -13,11 +13,16 @@ class Group extends Component {
     const textContent = () => {
       switch (langPref) {
         case 'en':
-          return english_name;
+          return <p>{english_name}</p>;
         case 'se':
-            return swedish_name;
+            return <p>{swedish_name}</p>;
         default:
-          return `${english_name} / ${swedish_name}`;
+          return (
+            <div>
+              <p>{english_name}</p>
+              <p>{swedish_name}</p>
+            </div>
+          );
       }
     }
 
@@ -30,7 +35,7 @@ class Group extends Component {
           <p className="family-list-item-numbers pl-1">
             ({total_seen}/{total_birds})
           </p>
-          <p>{textContent()}</p>
+          {textContent()}
         </li>
       </Link>
     );

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -29,18 +29,23 @@ class Bird extends Component {
     const textContent = () => {
       switch (langPref) {
         case "en":
-          return english_name;
+          return <p>{english_name}</p>;
         case "se":
-          return swedish_name;
+          return <p>{swedish_name}</p>;
         default:
-          return `${english_name} / ${swedish_name}`;
+          return (
+            <div>
+              <p>{english_name}</p>
+              <p>{swedish_name}</p>
+            </div>
+          );
       }
     };
   
     return (
       <li className="list-group-item">
         <i {...iconProps} />
-        <p>{textContent()}</p>
+        {textContent()}
         {
           this.state.showModal && (
             <Modal title="Confirm sighting" confirmButtonText={"Confirm"} close={this.toggleModal} action={() => markSeen(scientific_name)}>


### PR DESCRIPTION
When the group and bird components show names in both languages they are now multiline to improve readability.