### PR TITLE
Add/population setting

### DIFF
--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -22,8 +22,9 @@ export function fetchGroups(groupBy, populationThreshold = 9) {
   }
 }
 
-export function fetchGroup(groupedBy, groupName) {
-  const url = BASE_URL + `/${groupedBy}/${groupName}`;
+export function fetchGroup(groupedBy, groupName, populationThreshold = 9) {
+  const url = BASE_URL + `/${groupedBy}/${groupName}?population_category_at_least=${populationThreshold}`;
+  console.log(url)
   const promise = fetch(url, { credentials: "same-origin" }).then((r) =>
     r.json()
   );

--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -9,9 +9,9 @@ export const MARK_SEEN = 'MARK_SEEN';
 export const LOAD_SETTINGS = 'LOAD_SETTINGS';
 export const SAVE_SETTINGS = 'SAVE_SETTINGS';
 
-export function fetchGroups(groupBy) {
+export function fetchGroups(groupBy, populationThreshold = 9) {
   // group_by param must be singular
-  const url = BASE_URL + `/groups?group_by=${groupBy}`;
+  const url = BASE_URL + `/groups?group_by=${groupBy}&population_category_at_least=${populationThreshold}`;
 
   const promise = fetch(url, { credentials: 'same-origin' })
     .then(r => r.json());

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -9,7 +9,7 @@ class BirdList extends Component {
   componentDidMount() {
     const { groupedBy, groupName } = this.props.match.params;
 
-    this.props.fetchGroup(groupedBy, groupName);
+    this.props.fetchGroup(groupedBy, groupName, this.props.popThres);
   }
 
   render() {
@@ -42,6 +42,7 @@ const mapStateToProps = (state) => {
     totalBirds: state.selectedGroupData.total_birds,
     birds: state.selectedGroupData.birds,
     langPref: state.settingsData.language,
+    popThres: state.settingsData.populationThreshold
   };
 }
 

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -7,11 +7,9 @@ import Group from '../components/group';
 
 class GroupList extends Component {
   componentDidMount() {
-    const { groupedBy, fetchGroups, groupSingular} = this.props;
+    const { groupedBy, fetchGroups, groupSingular, popThres } = this.props;
 
-     if (groupSingular !== groupedBy) {
-       fetchGroups(groupSingular);
-     } 
+    fetchGroups(groupSingular, popThres); 
   }
 
   render() {
@@ -45,7 +43,8 @@ const mapStateToProps = (state) => {
     totalGroups: state.groupsData.total_groups,
     totalSeen: state.groupsData.total_seen,
     totalBirds: state.groupsData.total_birds,
-    langPref: state.settingsData.language
+    langPref: state.settingsData.language,
+    popThres: state.settingsData.populationThreshold
   };
 }
 

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -42,6 +42,23 @@ class Settings extends Component {
   render() {
     const { groupBy, seenConfirmation, language, populationThreshold } = this.state.settings;
 
+    const populationText = () => {
+      switch (+populationThreshold) {
+        case 5:
+          return "Include birds to the rarest of less than 100 observations in Sweden."
+        case 6:
+          return "Include yearly guest birds which do not breed here."
+        case 7:
+          return "Include birds which may be seen only once, every year or several years.";
+        case 8:
+          return "Include birds which may be seen once or a few times every 10 years."
+        case 9:
+          return "Include birds which have only been seen once or few times in Sweden ever.";
+        default:
+          return ""
+      }
+    }
+
     return (
       <form onSubmit={this.saveSettings}>
         <h2>Settings:</h2>
@@ -72,8 +89,8 @@ class Settings extends Component {
 
         <div className="form-group">
           <label className="mr-2">Population threshold:</label>
-          <p></p>
-          <input type="range" className="form-range w-100 hover-pointer" value={populationThreshold} min="5" max="9" />
+          <p><em>{populationText()}</em></p>
+          <input value={populationThreshold} min="5" max="9" type="range" className="form-range w-100 hover-pointer" onChange={(event) => this.settingsChange('populationThreshold', event.target.value)}/>
         </div>
 
         <button className="btn btn-primary">Submit</button>

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -40,7 +40,7 @@ class Settings extends Component {
   };
 
   render() {
-    const { groupBy, seenConfirmation, language } = this.state.settings;
+    const { groupBy, seenConfirmation, language, populationThreshold } = this.state.settings;
 
     return (
       <form onSubmit={this.saveSettings}>
@@ -68,6 +68,12 @@ class Settings extends Component {
             <option value="se">Swedish</option>
             <option value="both">Both</option>
           </select>
+        </div>
+
+        <div className="form-group">
+          <label className="mr-2">Population threshold:</label>
+          <p></p>
+          <input type="range" className="form-range w-100 hover-pointer" value={populationThreshold} min="5" max="9" />
         </div>
 
         <button className="btn btn-primary">Submit</button>

--- a/app/javascript/react_app/setting_defaults.js
+++ b/app/javascript/react_app/setting_defaults.js
@@ -1,7 +1,8 @@
 const SETTING_DEFAULTS = {
   groupBy: "family",
   seenConfirmation: true,
-  language: 'both'
+  language: 'both',
+  populationThreshold: 9
 };
 
 export default SETTING_DEFAULTS;


### PR DESCRIPTION
- Add populationThreshold to settings defaults. 9 is default
- Add population slider to settings component. 
- Update group_list and fetch_groups to use this setting
-  Update bird_list and fetch_group to use this setting

group_list component did mount can be refactored through a condition check on fetch groups -> only do if population threshold or groupBy has been changed in the settings. To do this we need to remember what populationThreshold the groups is based on previously to see if the groups data needs updating.