### PR TITLE
Refactor/prevent unnecessary fetch groups

### DIFF
--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -24,7 +24,6 @@ export function fetchGroups(groupBy, populationThreshold = 9) {
 
 export function fetchGroup(groupedBy, groupName, populationThreshold = 9) {
   const url = BASE_URL + `/${groupedBy}/${groupName}?population_category_at_least=${populationThreshold}`;
-  console.log(url)
   const promise = fetch(url, { credentials: "same-origin" }).then((r) =>
     r.json()
   );

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -20,7 +20,7 @@ class GroupList extends Component {
 
     return (
       <div>
-        <h1>All {totalGroups} {groupPlural}: </h1>
+        <h1>{totalGroups} {groupPlural}: </h1>
         <h3 className="mb-3">
           Birds seen: ({totalSeen}/{totalBirds})
         </h3>

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -7,9 +7,12 @@ import Group from '../components/group';
 
 class GroupList extends Component {
   componentDidMount() {
-    const { groupedBy, fetchGroups, groupSingular, userPopThres } = this.props;
+    const { groupedBy, populationThreshold, fetchGroups, groupSingular, userPopThres } = this.props;
 
-    fetchGroups(groupSingular, userPopThres); 
+    // check if we need to re-fetch the groups based on the url && user settings
+    if (groupedBy !== groupSingular || userPopThres !== populationThreshold) {
+      fetchGroups(groupSingular, userPopThres); 
+    }
   }
 
   render() {

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -7,13 +7,13 @@ import Group from '../components/group';
 
 class GroupList extends Component {
   componentDidMount() {
-    const { groupedBy, fetchGroups, groupSingular, popThres } = this.props;
+    const { groupedBy, fetchGroups, groupSingular, userPopThres } = this.props;
 
-    fetchGroups(groupSingular, popThres); 
+    fetchGroups(groupSingular, userPopThres); 
   }
 
   render() {
-    const { groups, totalGroups, totalBirds, totalSeen, groupPlural, langPref } = this.props;
+    const { groups, totalGroups, totalBirds, totalSeen, groupPlural, userLangPref } = this.props;
 
     return (
       <div>
@@ -24,7 +24,7 @@ class GroupList extends Component {
 
         <ul className="list-group">
           {groups.map((group) => {
-            return <Group key={group.scientific_name} groupedBy={groupPlural} langPref={langPref} {...group}/>;
+            return <Group key={group.scientific_name} groupedBy={groupPlural} langPref={userLangPref} {...group}/>;
           })}
         </ul>
       </div>
@@ -38,13 +38,14 @@ const mapDispatchToProps = (dispatch) => {
 
 const mapStateToProps = (state) => {
   return {
-    groupedBy: state.groupsData.grouped_by,
+    groupedBy: state.groupsData.grouped_by, // whether the data is grouped by 'order' or 'family'
+    populationThreshold: state.groupsData.population_threshold, // threshold used to filter the data
     groups: state.groupsData.groups,
     totalGroups: state.groupsData.total_groups,
     totalSeen: state.groupsData.total_seen,
     totalBirds: state.groupsData.total_birds,
-    langPref: state.settingsData.language,
-    popThres: state.settingsData.populationThreshold
+    userLangPref: state.settingsData.language,
+    userPopThres: state.settingsData.populationThreshold
   };
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,11 @@ class User < ApplicationRecord
 
   has_many :observations
 
+  POPULATION_DEFAULT = 9
+
   def family_birds_seen_count(family, population_category = nil)
     # this captures all the birds apart from the ones with unknown population (pop_cat 100)
-    population_category = 9 unless population_category
+    population_category = POPULATION_DEFAULT unless population_category
 
     Observation.joins(:bird).where('birds.family_id = :family and user_id = :user and birds.population_category <= :pop_cat',
                                   { family: family.id, user: self.id, pop_cat: population_category.to_i }).count
@@ -18,7 +20,7 @@ class User < ApplicationRecord
   
   def order_birds_seen_count(order, population_category = nil)
     # this captures all the birds apart from the ones with unknown population (pop_cat 100)
-    population_category = 9 unless population_category
+    population_category = POPULATION_DEFAULT unless population_category
 
     Observation.joins(bird: :family).where('families.order_id = :order and user_id = :user and birds.population_category <= :pop_cat',
                                   { order: order.id, user: self.id, pop_cat: population_category.to_i }).count
@@ -62,6 +64,7 @@ class User < ApplicationRecord
 
     group_data = {
       grouped_by: groups_class,
+      population_threshold: population_category || POPULATION_DEFAULT,
       total_groups: groups.count,
       total_seen: total_seen,
       total_birds: total_birds,


### PR DESCRIPTION
Added a condition to didComponentMount in group_list component so that it only re-fetches the groups when needed to. This is when either the user's populationThreshold setting changes or they navigation to a grouping which is different to which the groups data is grouped by.

Renamed components' props to be clearer