### PR TITLE
Remove unnecessary route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,5 @@ Rails.application.routes.draw do
   end
 
   root to: 'pages#home'
-  get '/settings', to: 'pages#home'
   get '/*path', to: 'pages#home'
 end


### PR DESCRIPTION
/settings is now a react page (within react-router-dom BrowserRouter) and therefore the route can be deleted.