### PR TITLE
Refactor/settings reducer and component

### DIFF
--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -5,7 +5,6 @@ import { bindActionCreators } from 'redux';
 import { HashLink } from 'react-router-hash-link';
 import { fetchGroup } from '../actions';
 
-import Wrapper from '../components/wrapper';
 import Bird from './bird';
 
 class BirdList extends Component {

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchGroups } from '../actions';
 
-import Wrapper from '../components/wrapper';
 import Group from '../components/group';
 
 class GroupList extends Component {

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -2,26 +2,13 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { saveSettings } from '../actions';
-import SETTING_DEFAULTS from '../setting_defaults';
 
 class Settings extends Component {
   constructor(props) {
     super(props);
 
-    const loadSettings = () => {
-      // load setting defaults
-      const settingsCopy = { ...SETTING_DEFAULTS };
-
-      // override settings defaults with user settings
-      for (const [key, value] of Object.entries(this.props.settings)) {
-        settingsCopy[key] = value;
-      }
-
-      return { settings: settingsCopy };
-    };
-
     // setting defaults overriden with user settings
-    this.state = loadSettings();
+    this.state = { settings: props.settings }
   }
 
   settingsChange = (id, value) => {

--- a/app/javascript/react_app/reducers/settings_reducer.js
+++ b/app/javascript/react_app/reducers/settings_reducer.js
@@ -5,7 +5,7 @@ const settingsReducer = (state = {}, action) => {
     return state;
   }
 
-  // get current state and update changed settings
+  // save updated state without mutating state directly
   const updatedSettings = { ...state, ...action.payload };
 
   switch (action.type) {

--- a/app/javascript/react_app/reducers/settings_reducer.js
+++ b/app/javascript/react_app/reducers/settings_reducer.js
@@ -5,19 +5,15 @@ const settingsReducer = (state = {}, action) => {
     return state;
   }
 
-  const settingsCopy = { ...state };
-
   // get current state and update changed settings
-  for (const [key, value] of Object.entries(action.payload)) {
-    settingsCopy[key] = value;
-  }
+  const updatedSettings = { ...state, ...action.payload };
 
   switch (action.type) {
     case LOAD_SETTINGS:
-      return settingsCopy;
+      return updatedSettings;
     case SAVE_SETTINGS:
-      localStorage.setItem(LOCAL_SETTINGS, JSON.stringify(settingsCopy));
-      return settingsCopy;
+      localStorage.setItem(LOCAL_SETTINGS, JSON.stringify(updatedSettings));
+      return updatedSettings;
     default:
       return state;
   }


### PR DESCRIPTION
- Settings reducer now uses Object.assign which refactors the code a lot.
- Cleaned up state.settings in settings component a lot. It can now use the state settings directly as it is preloaded and already is SETTINGS_DEFAULTS < user settings.