### PR TITLE
Fix/groups data after mark seen action

### DIFF
--- a/app/controllers/api/v1/observations_controller.rb
+++ b/app/controllers/api/v1/observations_controller.rb
@@ -8,7 +8,11 @@ class Api::V1::ObservationsController < Api::V1::BaseController
     authorize @bird, policy_class: ObservationPolicy
 
     if Observation.create(bird: @bird, user: current_user)
-      render json: { scientific_name: @bird.scientific_name, seen: true }
+      render json: {
+                    bird_scientific_name: @bird.scientific_name,
+                    bird_order_scientific_name: @bird.family.order.scientific_name,
+                    bird_family_scientific_name: @bird.family.scientific_name,
+                    seen: true }
     else
       throw_error
     end

--- a/app/javascript/react_app/reducers/groups_reducer.js
+++ b/app/javascript/react_app/reducers/groups_reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_GROUPS } from '../actions';
+import { FETCH_GROUPS, MARK_SEEN } from '../actions';
 
 const groupsReducer = (state, action) => {
   if (state === undefined) {
@@ -7,9 +7,33 @@ const groupsReducer = (state, action) => {
     };
   }
 
+  const updatedState = (familyScientfic, orderScientific) => {
+    if (state.groups.length === 0) return state;
+
+    const stateCopy = { ...state };
+    const checkName = (state.groupBy === 'order') ? orderScientific : familyScientfic;
+
+    const groupIndex = stateCopy.groups.findIndex(
+      (group) => group.scientific_name === checkName
+    );
+
+    stateCopy.total_seen += 1;
+
+    if (groupIndex !== -1) {
+      stateCopy.groups[groupIndex].total_seen += 1;
+    }
+
+    return stateCopy;
+  };
+
   switch (action.type) {
     case FETCH_GROUPS:
       return action.payload;
+    case MARK_SEEN:
+      return updatedState(
+        action.payload.family_scientific_name,
+        action.payload.order_scientific_name,
+      );
     default:
       return state;
   }

--- a/app/javascript/react_app/reducers/selected_group_reducer.js
+++ b/app/javascript/react_app/reducers/selected_group_reducer.js
@@ -26,7 +26,7 @@ const selectedGroupReducer = (state, action) => {
         return state;
       }
       return updatedState(
-        action.payload.scientific_name,
+        action.payload.bird_scientific_name,
         action.payload.seen,
       );
     default:


### PR DESCRIPTION
Before this fix, a user could go into a group(family/order) and mark a bird as seen. The bird's seen value would change and the group total_seen would update. However the groupsData total_seen and the group within which the bird belonged would not have its total_seen value updated. 

For example:
Before: groupsData: { total_seen: 0, groups: [{ total_seen: 0, ...}], ... } 
*goes to a family and marks a bird as seen*
*selected group values gets updated*
After: groupsData: { total_seen: 0, groups: [{ total_seen: 0, ...}], ... } 

Hence it was still the same and it was a bad user experience to not see the groupsData being updated.

This was because we prevented the groups being re-fetched unless their is a change in user settings of populationThreshold or GroupBy, this was to prevent excessive fetches which are quite expensive requests.

Now, the groupsReducer also reacts to the MarkSeen dispatch as well and updates necessary values. This was helped by updating the markSeen API endpoint which now returns the bird's family and order scientific_name. As this is used to find the necessary values to update in groupsData.