### PR TITLE
Add/bird details information modal

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -12,12 +12,24 @@
 }
 .modal-component {
   position: fixed;
-  height: 40vh;
-  max-width: 500px;
+  height: fit-content;
+  max-width: 550px;
   z-index: 100;
+
+  .detailsModalItem {
+    display: flex;
+
+    & > :first-child {
+      min-width: 50px;
+    }
+  }
 }
 @media (max-width: 576px) {
   .modal-component {
     max-width: 90vw;
+    
+      & .detailsModalContent {
+      font-size: 12.5px;
+    }
   }
 }

--- a/app/javascript/react_app/components/details_modal.jsx
+++ b/app/javascript/react_app/components/details_modal.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import Modal from './modal';
+
+const DetailsModal = ({ close }) => (
+  <Modal title="Details" close={close}>DetailsModal</Modal>
+);
+
+export default DetailsModal;

--- a/app/javascript/react_app/components/details_modal.jsx
+++ b/app/javascript/react_app/components/details_modal.jsx
@@ -1,8 +1,51 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Modal from './modal';
 
-const DetailsModal = ({ close }) => (
-  <Modal title="Details" close={close}>DetailsModal</Modal>
-);
+const DetailsModal = ({ close }) => {
+  const t = (strings, isKeyBold) => (
+    <div className="detailsModalItem">
+      <p className={isKeyBold && 'font-weight-bold'}>{strings[0]}</p>
+      <p>{strings[1]}</p>
+    </div>
+  );
+
+  return (
+    <Modal title="Shorthand detail symbols" close={close}>
+      <div className="detailsModalContent">
+        <p><em>Information is regarding to Sweden</em></p>
+
+        <br />
+
+        {t(['Hs', 'Breeding non-migratory bird'], true)}
+        {t(['Hf', 'Breeding migratory bird'], true)}
+        {t(['Hs+f', 'Breeding bird, part stays and part migrates'], true)}
+        {t(['Hs (f)', 'Breeding bird, most stay and minority migrates'], true)}
+
+        <br />
+
+        {t(['1', 'Est. Observations > 1,000,000'], true)}
+        {t(['2', 'Est. Observations > 100,000'], true)}
+        {t(['3', 'Est. Observations > 10,000'], true)}
+        {t(['4', 'Est. Observations > 100'], true)}
+        {t(['5', 'Est. Observations <= 100'], true)}
+
+        <br />
+
+        {t(['V', 'Can see in winter'], true)}
+        {t(['(V)', 'Can rarely been seen during winter'], true)}
+        {t(['F', 'Migratory guest in large amounts during spring and autumn'], true)}
+
+        <br />
+
+        <p><strong>T</strong></p>
+        {t(['*', 'Yearly guest which does not breed here'])}
+        {t(['**', 'Seen once every year or few years'])}
+        {t(['***', 'Seen once or a few times every 10 years'])}
+        {t(['****', 'Seen once or a few times in Sweden ever'])}
+      </div>
+    </Modal>
+  );
+};
 
 export default DetailsModal;

--- a/app/javascript/react_app/components/modal.jsx
+++ b/app/javascript/react_app/components/modal.jsx
@@ -29,9 +29,13 @@ const Modal = (props) => {
             {children}
           </div>
           <div className="modal-footer">
-            <button type="button" className="btn btn-primary hover-pointer" onClick={handleClick}>
-              {confirmButtonText}
-            </button>
+            {
+              action && (
+                <button type="button" className="btn btn-primary hover-pointer" onClick={handleClick}>
+                  {confirmButtonText}
+                </button>
+              )
+            }
             <button type="button" className="btn btn-secondary hover-pointer" onClick={close}>
               Close
             </button>

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -4,14 +4,20 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { markSeen } from '../actions';
 import Modal from '../components/modal';
+import DetailsModal from '../components/details_modal';
 
 class Bird extends Component {
   state = {
-    showSeenModal: false
+    showSeenModal: false,
+    showDetailsModal: false
   }
 
   toggleSeenModal = () => {
     this.setState({ showSeenModal: !this.state.showSeenModal });
+  }
+
+  toggleDetailsModal = () => {
+    this.setState({ showDetailsModal: !this.state.showDetailsModal });
   }
 
   render() {
@@ -52,13 +58,18 @@ class Bird extends Component {
           {textContent()}
         </div>
 
-        <small className="text-muted hover-pointer">{details}</small>
+        <small className="text-muted hover-pointer" onClick={this.toggleDetailsModal}>{details}</small>
 
         {
           this.state.showSeenModal && (
             <Modal title="Confirm sighting" confirmButtonText="Confirm" close={this.toggleSeenModal} action={() => markSeen(scientific_name)}>
               <p>Are you sure you want to mark this bird as seen?</p>
             </Modal>
+          )
+        }
+        {
+          this.state.showDetailsModal && (
+            <DetailsModal close={this.toggleDetailsModal} />
           )
         }
       </li>

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -7,11 +7,11 @@ import Modal from '../components/modal';
 
 class Bird extends Component {
   state = {
-    showModal: false
+    showSeenModal: false
   }
 
-  toggleModal = () => {
-    this.setState({ showModal: !this.state.showModal });
+  toggleSeenModal = () => {
+    this.setState({ showSeenModal: !this.state.showSeenModal });
   }
 
   render() {
@@ -25,7 +25,7 @@ class Bird extends Component {
     const iconProps = {
       className: seenClasses,
       // add click event only for birds not seen yet
-      ...(!seen && seenConfirmation && { onClick: this.toggleModal }), // confirmation modal
+      ...(!seen && seenConfirmation && { onClick: this.toggleSeenModal }), // confirmation modal
       ...(!seen && !seenConfirmation && { onClick: () => markSeen(scientific_name) }), // no confirmation modal
     };
 
@@ -52,11 +52,11 @@ class Bird extends Component {
           {textContent()}
         </div>
 
-        <small className="text-muted">{details}</small>
+        <small className="text-muted hover-pointer">{details}</small>
 
         {
-          this.state.showModal && (
-            <Modal title="Confirm sighting" confirmButtonText="Confirm" close={this.toggleModal} action={() => markSeen(scientific_name)}>
+          this.state.showSeenModal && (
+            <Modal title="Confirm sighting" confirmButtonText="Confirm" close={this.toggleSeenModal} action={() => markSeen(scientific_name)}>
               <p>Are you sure you want to mark this bird as seen?</p>
             </Modal>
           )

--- a/app/javascript/react_app/reducers/groups_reducer.js
+++ b/app/javascript/react_app/reducers/groups_reducer.js
@@ -14,7 +14,7 @@ const groupsReducer = (state, action) => {
     const checkName = (state.groupBy === 'order') ? orderScientific : familyScientfic;
 
     const groupIndex = stateCopy.groups.findIndex(
-      (group) => group.scientific_name === checkName
+      (group) => group.scientific_name === checkName,
     );
 
     stateCopy.total_seen += 1;


### PR DESCRIPTION
Add a modal which can be triggered by clicking the details text on any bird component. This modal essentially a legend that explains what the bird details shorthand symbols mean.

Also updated the modal component:
- Always centered regardless of size (fix css)
- Action button is now optional and its visibility depends on if an action has been passed down through props or not