### PR TITLE
Update/lists to become sortable

### DIFF
--- a/app/assets/stylesheets/components/_bird-card.scss
+++ b/app/assets/stylesheets/components/_bird-card.scss
@@ -4,5 +4,12 @@
   .bird-card-info {
     display: flex;
     align-items: center;
+
+    i, div {
+      min-width: 40px;
+    }
+    i {
+      font-size: 24px;
+    }
   }
 }

--- a/app/assets/stylesheets/components/_group.scss
+++ b/app/assets/stylesheets/components/_group.scss
@@ -35,16 +35,12 @@
     align-items: center;
     margin-bottom: 0.5rem;
     padding: 12px 15px 12px 15px;
+
     @include media-breakpoint-up(sm) {
       padding: 12px 30px 12px 30px;
     }
-
     &.group-item-with-progress {
       padding-bottom: 18px;
-    }
-    i {
-      font-size: 24px;
-      min-width: 40px;
     }
     p {
       margin-bottom: 0;

--- a/app/assets/stylesheets/components/_group.scss
+++ b/app/assets/stylesheets/components/_group.scss
@@ -4,7 +4,7 @@
     position: -webkit-sticky !important;
     position: sticky !important;
     top: 0px;
-    z-index: 100;
+    z-index: 40;
     background-color: $primary !important;
     color: #fff !important;
     font-weight: bolder !important;

--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -8,6 +8,7 @@ export const FETCH_GROUP = 'FETCH_GROUP';
 export const MARK_SEEN = 'MARK_SEEN';
 export const LOAD_SETTINGS = 'LOAD_SETTINGS';
 export const SAVE_SETTINGS = 'SAVE_SETTINGS';
+export const SORT_GROUPS = 'SORT_GROUPS';
 
 export function fetchGroups(groupBy, populationThreshold = 9) {
   // group_by param must be singular
@@ -82,5 +83,12 @@ export function saveSettings(settings) {
   return {
     type: SAVE_SETTINGS,
     payload: settings,
+  };
+}
+
+export function sortGroups(clickedHeader, userLangPref) {
+  return {
+    type: SORT_GROUPS,
+    payload: { clickedHeader, userLangPref },
   };
 }

--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -9,6 +9,7 @@ export const MARK_SEEN = 'MARK_SEEN';
 export const LOAD_SETTINGS = 'LOAD_SETTINGS';
 export const SAVE_SETTINGS = 'SAVE_SETTINGS';
 export const SORT_GROUPS = 'SORT_GROUPS';
+export const SORT_BIRDS = 'SORT_BIRDS';
 
 export function fetchGroups(groupBy, populationThreshold = 9) {
   // group_by param must be singular
@@ -89,6 +90,13 @@ export function saveSettings(settings) {
 export function sortGroups(clickedHeader, userLangPref) {
   return {
     type: SORT_GROUPS,
+    payload: { clickedHeader, userLangPref },
+  };
+}
+
+export function sortBirds(clickedHeader, userLangPref) {
+  return {
+    type: SORT_BIRDS,
     payload: { clickedHeader, userLangPref },
   };
 }

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -30,10 +30,10 @@ class BirdList extends Component {
         <ul className="list-group mt-3">
           <li key="group-header" className="list-group-item group-header bird-card">
             <div className="bird-card-info">
-              <i>-</i>
-              <p>Names</p>
+              <i className="hover-pointer">-</i>
+              <p className="hover-pointer">Names</p>
             </div>
-            <p>Details</p>
+            <p className="hover-pointer">Details</p>
           </li>
           {
             birds.map((birdProps) => (

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -1,9 +1,12 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { HashLink } from 'react-router-hash-link';
-import { fetchGroup } from '../actions';
+import { fetchGroup, sortBirds } from '../actions';
 
 import Bird from './bird';
 
@@ -16,7 +19,7 @@ class BirdList extends Component {
 
   render() {
     const {
-      birds, totalSeen, totalBirds, englishName, scientificName, langPref,
+      sortedBirds, totalSeen, totalBirds, englishName, scientificName, userLangPref,
     } = this.props;
 
     const title = englishName || scientificName || '...';
@@ -30,14 +33,14 @@ class BirdList extends Component {
         <ul className="list-group mt-3">
           <li key="group-header" className="list-group-item group-header bird-card">
             <div className="bird-card-info">
-              <div className="hover-pointer">-</div>
-              <p className="hover-pointer">Names</p>
+              <div className="hover-pointer" onClick={() => this.props.sortBirds('seen')}>-</div>
+              <p className="hover-pointer" onClick={() => this.props.sortBirds('name', userLangPref)}>Names</p>
             </div>
-            <p className="hover-pointer">Details</p>
+            <p className="hover-pointer" onClick={() => this.props.sortBirds('details')}>Details</p>
           </li>
           {
-            birds.map((birdProps) => (
-              <Bird key={birdProps.scientific_name} langPref={langPref} {...birdProps} />
+            sortedBirds.map((birdProps) => (
+              <Bird key={birdProps.scientific_name} langPref={userLangPref} {...birdProps} />
             ))
           }
         </ul>
@@ -53,10 +56,11 @@ const mapStateToProps = (state) => ({
   totalSeen: state.selectedGroupData.total_seen,
   totalBirds: state.selectedGroupData.total_birds,
   birds: state.selectedGroupData.birds,
-  langPref: state.settingsData.language,
+  sortedBirds: state.selectedGroupData.sortedBirds,
+  userLangPref: state.settingsData.language,
   popThres: state.settingsData.populationThreshold,
 });
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchGroup }, dispatch);
+const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchGroup, sortBirds }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(BirdList);

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -30,7 +30,7 @@ class BirdList extends Component {
         <ul className="list-group mt-3">
           <li key="group-header" className="list-group-item group-header bird-card">
             <div className="bird-card-info">
-              <i className="hover-pointer">-</i>
+              <div className="hover-pointer">-</div>
               <p className="hover-pointer">Names</p>
             </div>
             <p className="hover-pointer">Details</p>

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -17,6 +17,30 @@ class BirdList extends Component {
     this.props.fetchGroup(groupedBy, groupName, this.props.popThres);
   }
 
+  sortedByIndicator(header) {
+    const { sortedBy } = this.props;
+    if (!sortedBy) return null;
+
+    const getSymbol = (orderedBy) => {
+      switch (orderedBy) {
+        case 'asc':
+          return '∧';
+        case 'desc':
+          return '∨';
+        default:
+          return null;
+      }
+    };
+
+    const [key] = Object.keys(this.props.sortedBy);
+
+    if (header !== key) {
+      return null;
+    }
+
+    return getSymbol(sortedBy[key]);
+  }
+
   render() {
     const {
       sortedBirds, totalSeen, totalBirds, englishName, scientificName, userLangPref,
@@ -33,10 +57,16 @@ class BirdList extends Component {
         <ul className="list-group mt-3">
           <li key="group-header" className="list-group-item group-header bird-card">
             <div className="bird-card-info">
-              <div className="hover-pointer" onClick={() => this.props.sortBirds('seen')}>-</div>
-              <p className="hover-pointer" onClick={() => this.props.sortBirds('name', userLangPref)}>Names</p>
+              <div className="hover-pointer" onClick={() => this.props.sortBirds('seen')}>
+                {this.sortedByIndicator('seen') || '-'}
+              </div>
+              <p className="hover-pointer" onClick={() => this.props.sortBirds('name', userLangPref)}>
+                Names {this.sortedByIndicator('name')}
+              </p>
             </div>
-            <p className="hover-pointer" onClick={() => this.props.sortBirds('details')}>Details</p>
+            <p className="hover-pointer" onClick={() => this.props.sortBirds('details')}>
+              {this.sortedByIndicator('details')} Details
+            </p>
           </li>
           {
             sortedBirds.map((birdProps) => (
@@ -55,7 +85,7 @@ const mapStateToProps = (state) => ({
   swedishName: state.selectedGroupData.group_swedish_name,
   totalSeen: state.selectedGroupData.total_seen,
   totalBirds: state.selectedGroupData.total_birds,
-  birds: state.selectedGroupData.birds,
+  sortedBy: state.selectedGroupData.sortedBy,
   sortedBirds: state.selectedGroupData.sortedBirds,
   userLangPref: state.settingsData.language,
   popThres: state.settingsData.populationThreshold,

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -57,7 +57,7 @@ class BirdList extends Component {
         <ul className="list-group mt-3">
           <li key="group-header" className="list-group-item group-header bird-card">
             <div className="bird-card-info">
-              <div className="hover-pointer" onClick={() => this.props.sortBirds('seen')}>
+              <div className="hover-pointer pl-1" onClick={() => this.props.sortBirds('seen')}>
                 {this.sortedByIndicator('seen') || '-'}
               </div>
               <p className="hover-pointer" onClick={() => this.props.sortBirds('name', userLangPref)}>

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -20,6 +20,30 @@ class GroupList extends Component {
     }
   }
 
+  sortedByIndicator(header) {
+    const { sortedBy } = this.props;
+    if (!sortedBy) return '';
+
+    const getSymbol = (orderedBy) => {
+      switch (orderedBy) {
+        case 'asc':
+          return '∧';
+        case 'desc':
+          return '∨';
+        default:
+          return '';
+      }
+    };
+
+    const [key] = Object.keys(this.props.sortedBy);
+
+    if (header !== key) {
+      return '';
+    }
+
+    return getSymbol(sortedBy[key]);
+  }
+
   render() {
     const {
       sortedGroups, totalGroups, totalBirds, totalSeen, groupPlural, userLangPref,
@@ -35,10 +59,10 @@ class GroupList extends Component {
         <ul className="list-group">
           <li key="group-header" className="list-group-item group-header">
             <p className="group-list-item-numbers pl-1 hover-pointer" onClick={() => this.props.sortGroups('seen')}>
-              Seen
+              Seen {this.sortedByIndicator('seen')}
             </p>
             <div className="hover-pointer">
-              <p onClick={() => this.props.sortGroups('name', userLangPref)}>Names</p>
+              <p onClick={() => this.props.sortGroups('name', userLangPref)}>Names {this.sortedByIndicator('name')}</p>
             </div>
           </li>
           {
@@ -63,6 +87,7 @@ const mapStateToProps = (state) => ({
   groupedBy: state.groupsData.grouped_by, // whether the data is grouped by 'order' or 'family'
   populationThreshold: state.groupsData.population_threshold, // threshold used to filter the data
   sortedGroups: state.groupsData.sortedGroups,
+  sortedBy: state.groupsData.sortedBy,
   groups: state.groupsData.groups,
   totalGroups: state.groupsData.total_groups,
   totalSeen: state.groupsData.total_seen,

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -1,8 +1,10 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { fetchGroups } from '../actions';
+import { fetchGroups, sortGroups } from '../actions';
 
 import Group from '../components/group';
 
@@ -20,7 +22,7 @@ class GroupList extends Component {
 
   render() {
     const {
-      groups, totalGroups, totalBirds, totalSeen, groupPlural, userLangPref,
+      sortedGroups, totalGroups, totalBirds, totalSeen, groupPlural, userLangPref,
     } = this.props;
 
     return (
@@ -32,13 +34,15 @@ class GroupList extends Component {
 
         <ul className="list-group">
           <li key="group-header" className="list-group-item group-header">
-            <p className="group-list-item-numbers pl-1 hover-pointer">
+            <p className="group-list-item-numbers pl-1 hover-pointer" onClick={() => this.props.sortGroups('seen')}>
               Seen
             </p>
-            <div className="hover-pointer"><p>Names</p></div>
+            <div className="hover-pointer">
+              <p onClick={() => this.props.sortGroups('name', userLangPref)}>Names</p>
+            </div>
           </li>
           {
-            groups.map((group) => (
+            sortedGroups.map((group) => (
               <Group
                 key={group.scientific_name}
                 groupedBy={groupPlural}
@@ -53,11 +57,12 @@ class GroupList extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchGroups }, dispatch);
+const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchGroups, sortGroups }, dispatch);
 
 const mapStateToProps = (state) => ({
   groupedBy: state.groupsData.grouped_by, // whether the data is grouped by 'order' or 'family'
   populationThreshold: state.groupsData.population_threshold, // threshold used to filter the data
+  sortedGroups: state.groupsData.sortedGroups,
   groups: state.groupsData.groups,
   totalGroups: state.groupsData.total_groups,
   totalSeen: state.groupsData.total_seen,

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -62,7 +62,9 @@ class GroupList extends Component {
               Seen {this.sortedByIndicator('seen')}
             </p>
             <div className="hover-pointer">
-              <p onClick={() => this.props.sortGroups('name', userLangPref)}>Names {this.sortedByIndicator('name')}</p>
+              <p onClick={() => this.props.sortGroups('name', userLangPref)}>
+                Names {this.sortedByIndicator('name')}
+              </p>
             </div>
           </li>
           {
@@ -88,7 +90,6 @@ const mapStateToProps = (state) => ({
   populationThreshold: state.groupsData.population_threshold, // threshold used to filter the data
   sortedGroups: state.groupsData.sortedGroups,
   sortedBy: state.groupsData.sortedBy,
-  groups: state.groupsData.groups,
   totalGroups: state.groupsData.total_groups,
   totalSeen: state.groupsData.total_seen,
   totalBirds: state.groupsData.total_birds,

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -32,10 +32,10 @@ class GroupList extends Component {
 
         <ul className="list-group">
           <li key="group-header" className="list-group-item group-header">
-            <p className="group-list-item-numbers pl-1">
+            <p className="group-list-item-numbers pl-1 hover-pointer">
               Seen
             </p>
-            <div><p>Names</p></div>
+            <div className="hover-pointer"><p>Names</p></div>
           </li>
           {
             groups.map((group) => (

--- a/app/javascript/react_app/index.jsx
+++ b/app/javascript/react_app/index.jsx
@@ -29,6 +29,7 @@ const reducers = combineReducers({
 const initialState = {
   groupsData: {
     groups: [],
+    sortedGroups: [],
     total_groups: 0,
     total_seen: 0,
     total_birds: 0,

--- a/app/javascript/react_app/index.jsx
+++ b/app/javascript/react_app/index.jsx
@@ -36,6 +36,7 @@ const initialState = {
   },
   selectedGroupData: {
     birds: [],
+    sortedBirds: [],
     total_seen: 0,
     total_birds: 0,
   },

--- a/app/javascript/react_app/reducers/selected_group_reducer.js
+++ b/app/javascript/react_app/reducers/selected_group_reducer.js
@@ -1,6 +1,12 @@
-import { FETCH_GROUP, MARK_SEEN } from '../actions';
+import { FETCH_GROUP, MARK_SEEN, SORT_BIRDS } from '../actions';
 
 const selectedGroupReducer = (state, action) => {
+  if (state === undefined) {
+    return {
+      birds: [],
+    };
+  }
+
   const updatedState = (name, seen) => {
     const stateCopy = { ...state };
 
@@ -12,15 +18,70 @@ const selectedGroupReducer = (state, action) => {
     return stateCopy;
   };
 
-  if (state === undefined) {
+  const sortBirds = (birds, sortBy, userLangPref = null) => {
+    if (!sortBy) return birds;
+
+    let [key] = Object.keys(sortBy);
+    const order = sortBy[key];
+
+    if (key === 'name') {
+      if (userLangPref === 'se') {
+        key = 'swedish_name';
+      } else {
+        key = 'english_name';
+      }
+    }
+
+    const sortedBirds = [...birds].sort((a, b) => {
+      // handle by booleans
+      if (key === 'seen') {
+        if (a[key] === b[key]) {
+          return 0;
+        } if (a[key]) {
+          return order === 'asc' ? -1 : 1;
+        }
+        return order === 'asc' ? 1 : -1;
+      }
+
+      if (a[key] < b[key]) {
+        return order === 'asc' ? -1 : 1;
+      }
+      if (a[key] > b[key]) {
+        return order === 'asc' ? 1 : -1;
+      }
+      return 0;
+    });
+
+    return sortedBirds;
+  };
+
+  const handleSortHeaderClick = ({ clickedHeader, userLangPref }) => {
+    let newSortedBy = {};
+
+    // if the key exists, increment it null > asc > desc
+    if (state.sortedBy && clickedHeader in state.sortedBy) {
+      if (state.sortedBy[clickedHeader] === 'asc') {
+        newSortedBy[clickedHeader] = 'desc';
+      } else {
+        newSortedBy = null;
+      }
+    } else {
+      // it is null or a different clicked header
+      newSortedBy[clickedHeader] = 'asc';
+    }
+
     return {
-      birds: [],
+      sortedBirds: sortBirds(state.birds, newSortedBy, userLangPref),
+      sortedBy: newSortedBy,
     };
-  }
+  };
 
   switch (action.type) {
     case FETCH_GROUP:
-      return action.payload;
+      return {
+        ...action.payload,
+        sortedBirds: sortBirds(action.payload.birds, state.sortedBy),
+      };
     case MARK_SEEN:
       if (action.payload.error) {
         return state;
@@ -29,6 +90,11 @@ const selectedGroupReducer = (state, action) => {
         action.payload.bird_scientific_name,
         action.payload.seen,
       );
+    case SORT_BIRDS:
+      return {
+        ...state,
+        ...handleSortHeaderClick(action.payload),
+      };
     default:
       return state;
   }

--- a/app/javascript/react_app/reducers/selected_group_reducer.js
+++ b/app/javascript/react_app/reducers/selected_group_reducer.js
@@ -38,9 +38,9 @@ const selectedGroupReducer = (state, action) => {
         if (a[key] === b[key]) {
           return 0;
         } if (a[key]) {
-          return order === 'asc' ? -1 : 1;
+          return order === 'asc' ? 1 : -1;
         }
-        return order === 'asc' ? 1 : -1;
+        return order === 'asc' ? -1 : 1;
       }
 
       if (a[key] < b[key]) {


### PR DESCRIPTION
Make the list item headers interactive to be able to sort/order the groups/birds.
- Added an each action for each reducer: group and selectedGroup.
- Add indicators to the headers to help the user understand what the current order is

Clicking a header text causes an action which rotates the order state.
1. If order is default or the clicked header column is different to the way the data has currently been sorted, sort the data by that column ascending
2. Else if it is the same column:
  - order by descending if it was by ascending
  - Order the data by its default if it was descending.

There is now a sortedBy state within groupsData and selectedGroupsData which is used to increment the order steps as listed above.
It's state is either null meaning default or a hash, where the key is what key the data has been ordered by for example: seen or details and the value is 'asc' or 'desc'. With the exception of the names where they are always stored as just 'name' instead of for example 'english_name'. This is because the user may change their name language preference in the settings, so it is better to have a universal name.

This has caused one bug however: if the user's name language preference was for example: 'se' and then they ordered the data ascending for the name, but then changed their setting to 'en'. The data would be still sorted by english name ascending with the indicator showing an up arrow. If these state slices had access to this user setting this could be fixed.