### PR TITLE
fix/groups state after mark seen action

### DIFF
--- a/app/javascript/react_app/reducers/groups_reducer.js
+++ b/app/javascript/react_app/reducers/groups_reducer.js
@@ -20,6 +20,7 @@ const groupsReducer = (state, action) => {
 
     stateCopy.total_seen += 1;
 
+    // also updates sortedGroups as they are object references
     if (groupIndex !== -1) {
       stateCopy.groups[groupIndex].total_seen += 1;
     }
@@ -92,8 +93,8 @@ const groupsReducer = (state, action) => {
       };
     case MARK_SEEN:
       return updatedState(
-        action.payload.family_scientific_name,
-        action.payload.order_scientific_name,
+        action.payload.bird_family_scientific_name,
+        action.payload.bird_order_scientific_name,
       );
     case SORT_GROUPS:
       return {


### PR DESCRIPTION
Fix groups and sortedGroups seen values updating correctly after mark seen action. This error occurred due to changed variable name. sortedGroups get automatically updated after groups does as sortedGroups uses object references to groups.