### PR TITLE
Update/list header name sort

### DIFF
--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -19,7 +19,7 @@ class BirdList extends Component {
 
   sortedByIndicator(header) {
     const { sortedBy } = this.props;
-    if (!sortedBy) return null;
+    if (!sortedBy) return '';
 
     const getSymbol = (orderedBy) => {
       switch (orderedBy) {
@@ -28,17 +28,29 @@ class BirdList extends Component {
         case 'desc':
           return '∨';
         default:
-          return null;
+          return '';
       }
     };
 
-    const [key] = Object.keys(this.props.sortedBy);
+    const getShorthand = (lang) => {
+      switch (lang) {
+        case 'english_name':
+          return 'EN';
+        case 'swedish_name':
+          return 'SE';
+        default:
+          return '';
+      }
+    };
 
-    if (header !== key) {
-      return null;
+    const [key] = Object.keys(sortedBy);
+
+    if (header === key) {
+      return getSymbol(sortedBy[key]);
+    } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
+      return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
     }
-
-    return getSymbol(sortedBy[key]);
+    return '';
   }
 
   render() {

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -35,13 +35,25 @@ class GroupList extends Component {
       }
     };
 
-    const [key] = Object.keys(this.props.sortedBy);
+    const getShorthand = (lang) => {
+      switch (lang) {
+        case 'english_name':
+          return 'EN';
+        case 'swedish_name':
+          return 'SE';
+        default:
+          return '';
+      }
+    };
 
-    if (header !== key) {
-      return '';
+    const [key] = Object.keys(sortedBy);
+
+    if (header === key) {
+      return getSymbol(sortedBy[key]);
+    } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
+      return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
     }
-
-    return getSymbol(sortedBy[key]);
+    return '';
   }
 
   render() {

--- a/app/javascript/react_app/containers/lifelist.jsx
+++ b/app/javascript/react_app/containers/lifelist.jsx
@@ -37,7 +37,7 @@ class Lifelist extends Component {
     };
 
     const sortedByIndicator = (header) => {
-      if (!sortedBy) return null;
+      if (!sortedBy) return '';
 
       const getSymbol = (orderedBy) => {
         switch (orderedBy) {
@@ -46,17 +46,29 @@ class Lifelist extends Component {
           case 'desc':
             return '∨';
           default:
-            return null;
+            return '';
         }
       };
 
-      const [key] = Object.keys(this.props.sortedBy);
+      const getShorthand = (lang) => {
+        switch (lang) {
+          case 'english_name':
+            return 'EN';
+          case 'swedish_name':
+            return 'SE';
+          default:
+            return '';
+        }
+      };
 
-      if (header !== key) {
-        return null;
+      const [key] = Object.keys(sortedBy);
+
+      if (header === key) {
+        return getSymbol(sortedBy[key]);
+      } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
+        return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
       }
-
-      return getSymbol(sortedBy[key]);
+      return '';
     };
 
     return (

--- a/app/javascript/react_app/reducers/groups_reducer.js
+++ b/app/javascript/react_app/reducers/groups_reducer.js
@@ -28,19 +28,11 @@ const groupsReducer = (state, action) => {
     return stateCopy;
   };
 
-  const sortGroups = (groups, sortBy, userLangPref = null) => {
-    if (!sortBy) return groups;
+  const sortGroups = (groups, sortBy) => {
+    if (!sortBy) return [...groups];
 
-    let [key] = Object.keys(sortBy);
+    const [key] = Object.keys(sortBy);
     const order = sortBy[key];
-
-    if (key === 'name') {
-      if (userLangPref === 'se') {
-        key = 'swedish_name';
-      } else {
-        key = 'english_name';
-      }
-    }
 
     const sortedGroups = [...groups].sort((a, b) => {
       // sort by seen percentage
@@ -66,21 +58,49 @@ const groupsReducer = (state, action) => {
   };
 
   const handleSortHeaderClick = ({ clickedHeader, userLangPref }) => {
+    const { sortedBy } = state;
     let newSortedBy = {};
 
-    // if the key exists, increment it null > asc > desc
-    if (state.sortedBy && clickedHeader in state.sortedBy) {
-      if (state.sortedBy[clickedHeader] === 'asc') {
-        newSortedBy[clickedHeader] = 'desc';
+    const newSort = () => {
+      let key;
+
+      if (clickedHeader === 'name') {
+        if (userLangPref === 'se') {
+          key = 'swedish_name';
+        } else {
+          key = 'english_name';
+        }
       } else {
-        newSortedBy = null;
+        key = clickedHeader;
       }
-    } else { // it is null or a different clicked header
-      newSortedBy[clickedHeader] = 'asc';
+      newSortedBy[key] = 'asc';
+    };
+
+    // if the key exists, increment it null > asc > desc
+    if (sortedBy) {
+      if (clickedHeader in sortedBy || (clickedHeader === 'name' && (Object.keys(sortedBy)[0] === 'english_name' || Object.keys(sortedBy)[0] === 'swedish_name'))) {
+        const key = (clickedHeader === 'name') ? Object.keys(sortedBy)[0] : clickedHeader;
+
+        if (sortedBy[key] === 'asc') {
+          newSortedBy[key] = 'desc';
+        } else if (userLangPref === 'both' && key === 'english_name') {
+          // increment through two languages before going back to null
+          // en asc > en desc > se asc > se desc > null
+          newSortedBy.swedish_name = 'asc';
+        } else {
+          newSortedBy = null;
+        }
+      } else {
+        // new header click
+        newSort();
+      }
+    } else {
+      // was null
+      newSort();
     }
 
     return {
-      sortedGroups: sortGroups(state.groups, newSortedBy, userLangPref),
+      sortedGroups: sortGroups(state.groups, newSortedBy),
       sortedBy: newSortedBy,
     };
   };

--- a/app/javascript/react_app/reducers/selected_group_reducer.js
+++ b/app/javascript/react_app/reducers/selected_group_reducer.js
@@ -18,19 +18,11 @@ const selectedGroupReducer = (state, action) => {
     return stateCopy;
   };
 
-  const sortBirds = (birds, sortBy, userLangPref = null) => {
-    if (!sortBy) return birds;
+  const sortBirds = (birds, sortBy) => {
+    if (!sortBy) return [...birds];
 
-    let [key] = Object.keys(sortBy);
+    const [key] = Object.keys(sortBy);
     const order = sortBy[key];
-
-    if (key === 'name') {
-      if (userLangPref === 'se') {
-        key = 'swedish_name';
-      } else {
-        key = 'english_name';
-      }
-    }
 
     const sortedBirds = [...birds].sort((a, b) => {
       // handle by booleans
@@ -56,22 +48,49 @@ const selectedGroupReducer = (state, action) => {
   };
 
   const handleSortHeaderClick = ({ clickedHeader, userLangPref }) => {
+    const { sortedBy } = state;
     let newSortedBy = {};
 
-    // if the key exists, increment it null > asc > desc
-    if (state.sortedBy && clickedHeader in state.sortedBy) {
-      if (state.sortedBy[clickedHeader] === 'asc') {
-        newSortedBy[clickedHeader] = 'desc';
+    const newSort = () => {
+      let key;
+
+      if (clickedHeader === 'name') {
+        if (userLangPref === 'se') {
+          key = 'swedish_name';
+        } else {
+          key = 'english_name';
+        }
       } else {
-        newSortedBy = null;
+        key = clickedHeader;
+      }
+      newSortedBy[key] = 'asc';
+    };
+
+    // if the key exists, increment it null > asc > desc
+    if (sortedBy) {
+      if (clickedHeader in sortedBy || (clickedHeader === 'name' && (Object.keys(sortedBy)[0] === 'english_name' || Object.keys(sortedBy)[0] === 'swedish_name'))) {
+        const key = (clickedHeader === 'name') ? Object.keys(sortedBy)[0] : clickedHeader;
+
+        if (sortedBy[key] === 'asc') {
+          newSortedBy[key] = 'desc';
+        } else if (userLangPref === 'both' && key === 'english_name') {
+          // increment through two languages before going back to null
+          // en asc > en desc > se asc > se desc > null
+          newSortedBy.swedish_name = 'asc';
+        } else {
+          newSortedBy = null;
+        }
+      } else {
+        // new header click
+        newSort();
       }
     } else {
-      // it is null or a different clicked header
-      newSortedBy[clickedHeader] = 'asc';
+      // was null
+      newSort();
     }
 
     return {
-      sortedBirds: sortBirds(state.birds, newSortedBy, userLangPref),
+      sortedBirds: sortBirds(state.birds, newSortedBy),
       sortedBy: newSortedBy,
     };
   };


### PR DESCRIPTION
Update reducers to handle new sort functionality on userLangPref: 'both' 

When the user has the language preference setting saved as 'both'
and toggles the name in the list headers. It will now increment
both languages. EN>SE>NULL. Before it would just order by
english_name.

Now the user can toggle through both languages without having to
change their settings. As well as this, if they want to for
example order by Swedish to find a bird/group they can
still keep the English name which allows them to find a bird/group
if they only know the name in one language