### PR TITLE
Add/restore scroll position of group list

### DIFF
--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -15,6 +15,7 @@ export const CLEAR_FLASH_MESSAGE = 'CLEAR_FLASH_MESSAGE';
 export const FETCH_LIFELIST = 'FETCH_LIFELIST';
 export const SORT_LIFELIST = 'SORT_LIFELIST';
 export const SET_PREV_LOCATION = 'SET_PREV_LOCATION';
+export const SET_GROUP_LIST_SCROLL_POSITION = 'SET_GROUP_LIST_SCROLL_POSITION';
 
 export function fetchGroups(groupBy, populationThreshold = 9) {
   // group_by param must be singular
@@ -142,5 +143,12 @@ export function setPrevLocation(location) {
   return {
     type: SET_PREV_LOCATION,
     payload: location,
+  };
+}
+
+export function setGroupListScrollPos(x, y) {
+  return {
+    type: SET_GROUP_LIST_SCROLL_POSITION,
+    payload: { x, y },
   };
 }

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -4,20 +4,27 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { fetchGroups, sortGroups } from '../actions';
+import { fetchGroups, sortGroups, setGroupListScrollPos } from '../actions';
 
 import Group from '../components/group';
 
 class GroupList extends Component {
   componentDidMount() {
     const {
-      groupedBy, populationThreshold, groupSingular, userPopThres,
+      groupedBy, populationThreshold, groupSingular, userPopThres, prevScrollPos,
     } = this.props;
 
     // check if we need to re-fetch the groups based on the url && user settings
     if (groupedBy !== groupSingular || userPopThres !== populationThreshold) {
       this.props.fetchGroups(groupSingular, userPopThres);
     }
+
+    // scroll back to the last position on this page
+    window.scrollTo(prevScrollPos.x, prevScrollPos.y);
+  }
+
+  componentWillUnmount() {
+    this.props.setGroupListScrollPos(window.scrollX, window.scrollY);
   }
 
   sortedByIndicator(header) {
@@ -95,7 +102,10 @@ class GroupList extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ fetchGroups, sortGroups }, dispatch);
+// eslint-disable-next-line arrow-body-style
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ fetchGroups, sortGroups, setGroupListScrollPos }, dispatch);
+};
 
 const mapStateToProps = (state) => ({
   groupedBy: state.groupsData.grouped_by, // whether the data is grouped by 'order' or 'family'
@@ -107,6 +117,7 @@ const mapStateToProps = (state) => ({
   totalBirds: state.groupsData.total_birds,
   userLangPref: state.settingsData.language,
   userPopThres: state.settingsData.populationThreshold,
+  prevScrollPos: state.groupListScrollPos,
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(GroupList);

--- a/app/javascript/react_app/index.jsx
+++ b/app/javascript/react_app/index.jsx
@@ -17,6 +17,7 @@ import settingsReducer from './reducers/settings_reducer';
 import flashMessageReducer from './reducers/flash_message_reducer';
 import lifelistReducer from './reducers/lifelist_reducer';
 import prevLocationReducer from './reducers/prev_location_reducer';
+import groupListScrollPositionReducer from './reducers/group_list_scroll_position_reducer';
 
 // modules for loading the app with setting defaults and then user settings
 import SETTING_DEFAULTS from './setting_defaults';
@@ -30,6 +31,7 @@ const reducers = combineReducers({
   flashMessage: flashMessageReducer,
   lifelistData: lifelistReducer,
   prevLocation: prevLocationReducer,
+  groupListScrollPos: groupListScrollPositionReducer,
 });
 
 const initialState = {
@@ -53,6 +55,10 @@ const initialState = {
     sortedLifelist: [],
   },
   prevLocation: '/',
+  groupListScrollPos: {
+    x: 0,
+    y: 0,
+  },
 };
 
 // root, store and middlewares

--- a/app/javascript/react_app/reducers/group_list_scroll_position_reducer.js
+++ b/app/javascript/react_app/reducers/group_list_scroll_position_reducer.js
@@ -1,0 +1,14 @@
+import { SET_GROUP_LIST_SCROLL_POSITION } from '../actions';
+
+const groupListScrollPositionReducer = (state, action) => {
+  if (!state) return { x: 0, y: 0 };
+
+  switch (action.type) {
+    case SET_GROUP_LIST_SCROLL_POSITION:
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default groupListScrollPositionReducer;


### PR DESCRIPTION
When navigating away from the group list component/page the scroll position now gets saved (on unmount). And when you go back to that group list page it will scroll perfectly back to where you originally was. This functionality is much better than the old one where it would use hash links so regardless of which link you clicked and where it was, when you go back it became at the top of the page. Meaning the positioning was likely going to be different to how you left it.

This new functionality is thanks to a new state slice: groupListScrollPos, reducer: groupListScrollPositionReducer and action: setGroupListScrollPos(x, y). The saving of the scroll position happens on component unmount and is restored on component did mount. The initial state of this slice is { x: 0, y: 0 }