### PR TITLE
Add/search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| 'https://github.com/#{repo}.git' }
+git_source(:github) { |_repo| "https://github.com/#{repo}.git" }
 
 ruby '2.6.6'
 
@@ -36,6 +36,8 @@ gem 'pundit'
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass'
 gem 'simple_form'
+
+gem 'pg_search'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,9 @@ GEM
     parser (3.0.1.1)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pg_search (2.3.5)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -266,6 +269,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
+  pg_search
   pry-byebug
   pry-rails
   puma (~> 4.1)

--- a/app/controllers/api/v1/birds_controller.rb
+++ b/app/controllers/api/v1/birds_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::BirdsController < Api::V1::BaseController
+  def search
+    query_string = params[:query_string]
+
+    if query_string
+      threshold = params[:population_category_at_least]
+      lang = params[:language_preference]
+
+      birds = Bird.search_by_name(query_string, lang, threshold)
+      render json: birds
+    else
+      throw_error
+    end
+  end
+
+  private
+
+  def throw_error
+    render json: { error: "Bad request" }, status: :bad_request
+  end
+end

--- a/app/models/bird.rb
+++ b/app/models/bird.rb
@@ -1,5 +1,3 @@
-require 'pry-byebug'
-
 class Bird < ApplicationRecord
   validates :scientific_name, :english_name, :swedish_name, presence: true
   validates :scientific_name, :english_name, :swedish_name, uniqueness: true

--- a/app/models/bird.rb
+++ b/app/models/bird.rb
@@ -1,7 +1,53 @@
+require 'pry-byebug'
+
 class Bird < ApplicationRecord
   validates :scientific_name, :english_name, :swedish_name, presence: true
   validates :scientific_name, :english_name, :swedish_name, uniqueness: true
 
   belongs_to :family
   has_many :observations
+
+  include PgSearch::Model
+  pg_search_scope :search_by_english_and_scientific_name,
+                  against: [:scientific_name, :english_name],
+                  using: {
+                    trigram: { word_similarity: true }
+                  }
+  pg_search_scope :search_by_swedish_and_scientific_name,
+                  against: [:scientific_name, :swedish_name],
+                  using: {
+                    trigram: { word_similarity: true }
+                  }
+  pg_search_scope :search_by_all_names,
+                  against: [:scientific_name, :english_name, :swedish_name],
+                  using: {
+                    trigram: { word_similarity: true }
+                  }
+
+  def self.search_by_name(query_string, language_pref, population_threshold)
+    language_pref ||= "both"
+    population_threshold ||= 9
+    lang = language_pref.downcase
+
+    birds = []
+
+    case lang
+    when "en"
+      birds = search_by_english_and_scientific_name(query_string)
+    when "se"
+      birds = search_by_swedish_and_scientific_name(query_string)
+    else
+      birds = search_by_all_names(query_string)
+    end
+
+    # skip birds with a population category that is not set or is rarer than given threshold
+    birds = birds.select { |b| !b.population_category.nil? && b.population_category <= population_threshold.to_i }
+
+    birds.map do |b|
+      x = { scientific_name: b.scientific_name }
+      x[:english_name] = b.english_name unless lang == "se"
+      x[:swedish_name] = b.swedish_name unless lang == "en"
+      x
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     namespace :v1 do
       get '/groups', to: 'groups#index'
+      get 'birds/search', to: 'birds#search'
       
       resources :families, only: [:show]
       resources :orders, only: [:show]

--- a/db/migrate/20210601111807_install_pg_trigram_extension.rb
+++ b/db/migrate/20210601111807_install_pg_trigram_extension.rb
@@ -1,0 +1,9 @@
+class InstallPgTrigramExtension < ActiveRecord::Migration[6.0]
+  def up
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+  end
+
+  def down
+    execute "DROP EXTENSION IF EXISTS pg_trgm;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_14_073739) do
+ActiveRecord::Schema.define(version: 2021_06_01_111807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "birds", force: :cascade do |t|
     t.string "scientific_name"


### PR DESCRIPTION
Add new API endpoint birds/search. Returns an array of birds based on your search query. Uses the added pg extension trigram and the ruby gem pg_search
Takes three params:
1. query_string (required)
2. population_category_at_least (optional)
3. language_preference (optional -> defaults to "both")

language_preference param changed what names of the bird you search against and what names are returned
- "en" -> scientific_name and english_name
- "se" -> scientific_name and swedish_name
- "both" -> scientific_name, english_name and swedish_name