### PR TITLE
Add/group header component

### DIFF
--- a/app/assets/stylesheets/components/_group.scss
+++ b/app/assets/stylesheets/components/_group.scss
@@ -1,5 +1,5 @@
 .container ul.list-group, ol.list-group {
-  li.group-header {
+  li#group-header {
     position: sticky !important;
     position: -webkit-sticky !important;
     position: sticky !important;

--- a/app/javascript/react_app/components/group_header.jsx
+++ b/app/javascript/react_app/components/group_header.jsx
@@ -1,0 +1,106 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+const GroupHeader = ({
+  action, sortedBy, userLangPref, columns,
+}) => {
+  const sortedByIndicator = (header) => {
+    if (!sortedBy) return null;
+
+    const getSymbol = (orderedBy) => {
+      switch (orderedBy) {
+        case 'asc':
+          return '∧';
+        case 'desc':
+          return '∨';
+        default:
+          return '';
+      }
+    };
+
+    const getShorthand = (lang) => {
+      switch (lang) {
+        case 'english_name':
+          return 'EN';
+        case 'swedish_name':
+          return 'SE';
+        default:
+          return '';
+      }
+    };
+
+    const [key] = Object.keys(sortedBy);
+
+    if (header === key) {
+      return getSymbol(sortedBy[key]);
+    } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
+      return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
+    }
+    return null;
+  };
+
+  const text = ({ title, sortRef, replace }, reverse) => {
+    const indicator = sortedByIndicator(sortRef);
+
+    // if set to true and items were sorted by this column
+    // return indicator, otherwise just the title
+    if (replace) {
+      return (indicator) || title;
+    }
+
+    const t = [];
+
+    t.push(title);
+    t.push(' ');
+    t.push(indicator);
+
+    if (reverse) t.reverse();
+
+    return t;
+  };
+
+  const content = (column, index) => {
+    let classes = 'hover-pointer';
+    let reverse = false;
+
+    if (index === 0) {
+      classes += ' list-item-start';
+    // at least the third elem and is the last element
+    } else if (index >= 2 && index + 1 === columns.length) {
+      classes += ' list-item-end';
+      reverse = true;
+    } else {
+      classes += ' list-item-grow';
+    }
+
+    if (column.small) classes += '-small';
+
+    let onClick;
+
+    if (column.sortRef === 'name') {
+      onClick = () => action(column.sortRef, userLangPref);
+    } else {
+      onClick = () => action(column.sortRef);
+    }
+
+    const props = {
+      key: column.title,
+      className: classes,
+      onClick,
+    };
+
+    return <p {...props}>{text(column, reverse)}</p>;
+  };
+
+  return (
+    <li key="group-header" className="list-group-item group-header">
+      {
+        columns.map((column, index) => (
+          content(column, index)
+        ))
+      }
+    </li>
+  );
+};
+
+export default GroupHeader;

--- a/app/javascript/react_app/components/group_header.jsx
+++ b/app/javascript/react_app/components/group_header.jsx
@@ -93,7 +93,7 @@ const GroupHeader = ({
   };
 
   return (
-    <li key="group-header" className="list-group-item group-header">
+    <li key="group-header" id="group-header" className="list-group-item">
       {
         columns.map((column, index) => (
           content(column, index)

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -10,6 +10,7 @@ import { fetchGroup, sortBirds } from '../actions';
 
 import Bird from './bird';
 import BackLink from '../components/back_link';
+import GroupHeader from '../components/group_header';
 
 class BirdList extends Component {
   componentDidMount() {
@@ -35,48 +36,23 @@ class BirdList extends Component {
     }
   }
 
-  sortedByIndicator(header) {
-    const { sortedBy } = this.props;
-    if (!sortedBy) return '';
-
-    const getSymbol = (orderedBy) => {
-      switch (orderedBy) {
-        case 'asc':
-          return '∧';
-        case 'desc':
-          return '∨';
-        default:
-          return '';
-      }
-    };
-
-    const getShorthand = (lang) => {
-      switch (lang) {
-        case 'english_name':
-          return 'EN';
-        case 'swedish_name':
-          return 'SE';
-        default:
-          return '';
-      }
-    };
-
-    const [key] = Object.keys(sortedBy);
-
-    if (header === key) {
-      return getSymbol(sortedBy[key]);
-    } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
-      return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
-    }
-    return '';
-  }
-
   render() {
     const {
-      sortedBirds, totalSeen, totalBirds, englishName, scientificName, userLangPref,
+      sortedBirds, totalSeen, totalBirds, englishName, scientificName, userLangPref, sortedBy
     } = this.props;
 
     const title = englishName || scientificName || '...';
+
+    const groupHeaderProps = {
+      sortedBy,
+      action: this.props.sortBirds,
+      userLangPref,
+      columns: [
+        { title: 'Seen', sortRef: 'seen' },
+        { title: 'Names', sortRef: 'name' },
+        { title: 'Details', sortRef: 'details' },
+      ],
+    };
 
     return (
       <>
@@ -86,17 +62,8 @@ class BirdList extends Component {
         <BackLink to="/" />
 
         <ul className="list-group mt-3">
-          <li key="group-header" className="list-group-item group-header">
-            <p className="list-item-start hover-pointer" onClick={() => this.props.sortBirds('seen')}>
-              Seen {this.sortedByIndicator('seen')}
-            </p>
-            <p className="list-item-grow hover-pointer" onClick={() => this.props.sortBirds('name', userLangPref)}>
-              Names {this.sortedByIndicator('name')}
-            </p>
-            <p className="list-item-end hover-pointer" onClick={() => this.props.sortBirds('details')}>
-              {this.sortedByIndicator('details')} Details
-            </p>
-          </li>
+          <GroupHeader {...groupHeaderProps} />
+
           {
             sortedBirds.map((birdProps) => (
               <Bird key={birdProps.scientific_name} langPref={userLangPref} {...birdProps} />

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -26,8 +26,8 @@ class BirdList extends Component {
       const e = document.getElementById(hash.slice(1));
 
       if (e) {
-        const header = document.getElementsByClassName('group-header');
-        const headerHeight = header ? header[0].getBoundingClientRect().height : 0;
+        const header = document.getElementById('group-header');
+        const headerHeight = header ? header.getBoundingClientRect().height : 0;
 
         const yPos = e.getBoundingClientRect().top - headerHeight;
 

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -8,6 +8,7 @@ import { fetchGroups, sortGroups, setGroupListScrollPos } from '../actions';
 
 import Group from '../components/group';
 import SearchBar from './search_bar';
+import GroupHeader from "../components/group_header";
 
 class GroupList extends Component {
   componentDidMount() {
@@ -28,46 +29,20 @@ class GroupList extends Component {
     this.props.setGroupListScrollPos(window.scrollX, window.scrollY);
   }
 
-  sortedByIndicator(header) {
-    const { sortedBy } = this.props;
-    if (!sortedBy) return '';
-
-    const getSymbol = (orderedBy) => {
-      switch (orderedBy) {
-        case 'asc':
-          return '∧';
-        case 'desc':
-          return '∨';
-        default:
-          return '';
-      }
-    };
-
-    const getShorthand = (lang) => {
-      switch (lang) {
-        case 'english_name':
-          return 'EN';
-        case 'swedish_name':
-          return 'SE';
-        default:
-          return '';
-      }
-    };
-
-    const [key] = Object.keys(sortedBy);
-
-    if (header === key) {
-      return getSymbol(sortedBy[key]);
-    } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
-      return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
-    }
-    return '';
-  }
-
   render() {
     const {
-      sortedGroups, totalGroups, totalBirds, totalSeen, groupPlural, userLangPref,
+      sortedGroups, totalGroups, totalBirds, totalSeen, groupPlural, userLangPref, sortedBy,
     } = this.props;
+
+    const groupHeaderProps = {
+      sortedBy,
+      action: this.props.sortGroups,
+      userLangPref,
+      columns: [
+        { title: 'Seen', sortRef: 'seen' },
+        { title: 'Names', sortRef: 'name' },
+      ],
+    };
 
     return (
       <>
@@ -79,16 +54,8 @@ class GroupList extends Component {
         <SearchBar />
 
         <ul className="list-group mt-4">
-          <li key="group-header" className="list-group-item group-header">
-            <p className="list-item-start hover-pointer" onClick={() => this.props.sortGroups('seen')}>
-              Seen {this.sortedByIndicator('seen')}
-            </p>
-            <div className="hover-pointer">
-              <p onClick={() => this.props.sortGroups('name', userLangPref)}>
-                Names {this.sortedByIndicator('name')}
-              </p>
-            </div>
-          </li>
+          <GroupHeader {...groupHeaderProps}/>
+
           {
             sortedGroups.map((group) => (
               <Group

--- a/app/javascript/react_app/containers/lifelist.jsx
+++ b/app/javascript/react_app/containers/lifelist.jsx
@@ -8,6 +8,7 @@ import { bindActionCreators } from 'redux';
 import { fetchLifelist, sortLifelist } from '../actions';
 
 import BackLink from '../components/back_link';
+import GroupHeader from '../components/group_header';
 
 class Lifelist extends Component {
   componentDidMount() {
@@ -38,39 +39,17 @@ class Lifelist extends Component {
       }
     };
 
-    const sortedByIndicator = (header) => {
-      if (!sortedBy) return '';
-
-      const getSymbol = (orderedBy) => {
-        switch (orderedBy) {
-          case 'asc':
-            return '∧';
-          case 'desc':
-            return '∨';
-          default:
-            return '';
-        }
-      };
-
-      const getShorthand = (lang) => {
-        switch (lang) {
-          case 'english_name':
-            return 'EN';
-          case 'swedish_name':
-            return 'SE';
-          default:
-            return '';
-        }
-      };
-
-      const [key] = Object.keys(sortedBy);
-
-      if (header === key) {
-        return getSymbol(sortedBy[key]);
-      } if (header === 'name' && (key === 'english_name' || key === 'swedish_name')) {
-        return `(${getShorthand(key)} ${getSymbol(sortedBy[key])})`;
-      }
-      return '';
+    const groupHeaderProps = {
+      sortedBy,
+      action: this.props.sortLifelist,
+      userLangPref,
+      columns: [
+        {
+          title: '#', sortRef: 'index', replace: true, small: true,
+        },
+        { title: 'Names', sortRef: 'name' },
+        { title: 'Date', sortRef: 'date' },
+      ],
     };
 
     return (
@@ -80,26 +59,7 @@ class Lifelist extends Component {
         <BackLink to="/" />
 
         <ol className="list-group">
-          <li key="group-header" className="list-group-item group-header mt-2">
-            <p
-              className="list-item-start-small hover-pointer"
-              onClick={() => this.props.sortLifelist('index')}
-            >
-              {sortedByIndicator('index') || '#'}
-            </p>
-            <p
-              className="list-item-grow hover-pointer"
-              onClick={() => this.props.sortLifelist('name', userLangPref)}
-            >
-              Names {sortedByIndicator('name')}
-            </p>
-            <p
-              className="list-item-end hover-pointer"
-              onClick={() => this.props.sortLifelist('created_at')}
-            >
-              {sortedByIndicator('created_at')} Date
-            </p>
-          </li>
+          <GroupHeader {...groupHeaderProps} />
 
           {lifelist.map(({ created_at, bird, index }) => (
             <li className="list-group-item" key={bird.scientific_name}>


### PR DESCRIPTION
Created a new component: Group Header. This component replaces all the groupheader code in: 
- GroupList
- BirdList
- Lifelist

This simplifies and cleans up the code a lot as well as makes it easier to implement tweaks to the header.

The component needs the following props:
```
{
      sortedBy, // the state slice of how the items are currently sorted
      action: // the sort action from the action index to sort the data
      userLangPref, // users language preference
      columns: [ // the titles that you want in the header
        {
          title: '#', sortRef: 'index', replace: true, small: true,
        },
        { title: 'Names', sortRef: 'name' },
        { title: 'Date', sortRef: 'date' },
      ],
    };
   // where title is the actual text, sortRef is the text that gets saved in sortedBy for that column,
```
The header will automatically flip the column's title and indicator if it is the last column and is at least the 3rd column. 
In columns:
- Add replace to true, If you wish for a title to only show it's indicator when the items are sorted by it, add 'replace: true' to the respective column in the props.
- Add small to true, if you want that column smaller (use it if the respective column in the list items use small)