### PR TITLE
Refactor/class components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,13 @@
     "rules": {
         "react/jsx-one-expression-per-line": "off",
         "react/destructuring-assignment": "off",
-        "react/jsx-props-no-spreading": "off"
+        "react/jsx-props-no-spreading": "off",
+        "react/prop-types": "off",
+        "camelcase": "off",
+        "no-restricted-globals": "off",
+        "jsx-a11y/no-static-element-interactions": "off",
+        "jsx-a11y/click-events-have-key-events": "off",
+        "jsx-a11y/no-noninteractive-element-interactions": "off",
+        "jsx-a11y/label-has-associated-control": "off"
     }
 }

--- a/app/javascript/react_app/actions/index.js
+++ b/app/javascript/react_app/actions/index.js
@@ -3,21 +3,21 @@ const BASE_URL = '/api/v1';
 export const LOCAL_SETTINGS = 'swedishBirdsSettings';
 
 // actions
-export const FETCH_GROUPS = 'FETCH_GROUPS';
-export const FETCH_GROUP = 'FETCH_GROUP';
-export const MARK_SEEN = 'MARK_SEEN';
 export const LOAD_SETTINGS = 'LOAD_SETTINGS';
 export const SAVE_SETTINGS = 'SAVE_SETTINGS';
+export const FETCH_GROUPS = 'FETCH_GROUPS';
 export const SORT_GROUPS = 'SORT_GROUPS';
+export const FETCH_GROUP = 'FETCH_GROUP';
 export const SORT_BIRDS = 'SORT_BIRDS';
-export const SET_FLASH_MESSAGE = 'SET_FLASH_MESSAGE';
-export const CLEAR_FLASH_MESSAGE = 'CLEAR_FLASH_MESSAGE';
+export const MARK_SEEN = 'MARK_SEEN';
 export const FETCH_LIFELIST = 'FETCH_LIFELIST';
 export const SORT_LIFELIST = 'SORT_LIFELIST';
-export const SET_PREV_LOCATION = 'SET_PREV_LOCATION';
-export const SET_GROUP_LIST_SCROLL_POSITION = 'SET_GROUP_LIST_SCROLL_POSITION';
 export const FETCH_SEARCH_BIRDS = 'FETCH_SEARCH_BIRDS';
 export const CLEAR_SEARCH_BIRDS = 'CLEAR_SEARCH_BIRDS';
+export const SET_FLASH_MESSAGE = 'SET_FLASH_MESSAGE';
+export const CLEAR_FLASH_MESSAGE = 'CLEAR_FLASH_MESSAGE';
+export const SET_PREV_LOCATION = 'SET_PREV_LOCATION';
+export const SET_GROUP_LIST_SCROLL_POSITION = 'SET_GROUP_LIST_SCROLL_POSITION';
 
 export function fetchGroups(groupBy, populationThreshold = 9) {
   // group_by param must be singular

--- a/app/javascript/react_app/components/back_link.jsx
+++ b/app/javascript/react_app/components/back_link.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useStore } from 'react-redux';

--- a/app/javascript/react_app/components/checkbox.jsx
+++ b/app/javascript/react_app/components/checkbox.jsx
@@ -5,15 +5,16 @@ class Checkbox extends Component {
   constructor(props) {
     super(props);
 
-    this._isMounted = false;
+    this.componentIsMounted = false;
 
     this.state = {
       animateClass: false,
     };
+    this.removeAnimateClass = this.removeAnimateClass.bind(this);
   }
 
   componentDidMount() {
-    this._isMounted = true;
+    this.componentIsMounted = true;
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -28,39 +29,40 @@ class Checkbox extends Component {
   }
 
   componentWillUnmount() {
-    this._isMounted = false;
+    this.componentIsMounted = false;
   }
 
   animate() {
     this.setState({ animateClass: true });
   }
 
-  removeAnimateClass = async () => {
+  async removeAnimateClass() {
     await setTimeout(() => {
-      if (this._isMounted) {
+      if (this.componentIsMounted) {
         this.setState({ animateClass: false });
       }
     }, 700);
   }
 
+  // eslint-disable-next-line class-methods-use-this
   changeHandler() {
     return false;
   }
 
   render() {
     const { checked, onClick } = this.props;
-    let classes = "checkbox-input";
+    let classes = 'checkbox-input';
     classes += (this.state.animateClass) ? ' animate' : '';
 
     const props = {
-      type: "checkbox",
+      type: 'checkbox',
       className: classes,
       onClick,
       onChange: this.changeHandler,
       checked,
     };
 
-    return <input {...props}/>
+    return <input {...props} />;
   }
 }
 

--- a/app/javascript/react_app/components/checkbox.jsx
+++ b/app/javascript/react_app/components/checkbox.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 
 class Checkbox extends Component {

--- a/app/javascript/react_app/components/details_modal.jsx
+++ b/app/javascript/react_app/components/details_modal.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import Modal from './modal';
 

--- a/app/javascript/react_app/components/group.jsx
+++ b/app/javascript/react_app/components/group.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-/* eslint-disable camelcase */
 import React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/app/javascript/react_app/components/group_header.jsx
+++ b/app/javascript/react_app/components/group_header.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 const GroupHeader = ({

--- a/app/javascript/react_app/components/modal.jsx
+++ b/app/javascript/react_app/components/modal.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 const Modal = (props) => {

--- a/app/javascript/react_app/components/modal.jsx
+++ b/app/javascript/react_app/components/modal.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable react/prop-types */
 import React from 'react';
 

--- a/app/javascript/react_app/components/navbar.jsx
+++ b/app/javascript/react_app/components/navbar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+
 import logo from '../../../assets/images/transparent_64.png';
 
 const Navbar = () => (

--- a/app/javascript/react_app/components/wrapper.jsx
+++ b/app/javascript/react_app/components/wrapper.jsx
@@ -1,6 +1,7 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 
-const Wrapper = ({children}) => (
+const Wrapper = ({ children }) => (
   <div className="container my-5">
     <div className="row justify-content-center">
       <div className="col-12 col-lg-8">

--- a/app/javascript/react_app/components/wrapper.jsx
+++ b/app/javascript/react_app/components/wrapper.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 const Wrapper = ({ children }) => (

--- a/app/javascript/react_app/containers/app.jsx
+++ b/app/javascript/react_app/containers/app.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { Route, Switch, Redirect } from 'react-router-dom';

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -33,11 +33,11 @@ class Bird extends Component {
   }
 
   toggleDetailsModal() {
-    this.setState({ showDetailsModal: !this.state.showDetailsModal });
+    this.setState((prevState) => ({ showDetailsModal: !prevState.showDetailsModal }));
   }
 
   toggleSeenModal() {
-    this.setState({ showSeenModal: !this.state.showSeenModal });
+    this.setState((prevState) => ({ showSeenModal: !prevState.showSeenModal }));
   }
 
   render() {

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -1,3 +1,7 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable react/prop-types */
+/* eslint-disable quotes */
 /* eslint-disable camelcase */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -10,20 +14,27 @@ import Checkbox from '../components/checkbox';
 import { dashify, nameContent } from '../utils';
 
 class Bird extends Component {
-  state = {
-    showSeenModal: false,
-    showDetailsModal: false
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showSeenModal: false,
+      showDetailsModal: false,
+    };
+    this.toggleSeenModal = this.toggleSeenModal.bind(this);
+    this.toggleDetailsModal = this.toggleDetailsModal.bind(this);
+    this.handleMarkSeen = this.handleMarkSeen.bind(this);
   }
 
-  toggleSeenModal = () => {
+  toggleSeenModal() {
     this.setState({ showSeenModal: !this.state.showSeenModal });
   }
 
-  toggleDetailsModal = () => {
+  toggleDetailsModal() {
     this.setState({ showDetailsModal: !this.state.showDetailsModal });
   }
 
-  handleMarkSeen = () => {
+  handleMarkSeen() {
     this.props.markSeen(this.props.scientific_name);
     this.props.setFlashMessage("Bird marked as seen!");
   }
@@ -72,6 +83,9 @@ const mapStateToProps = (state) => ({
   seenConfirmation: state.settingsData.seenConfirmation,
 });
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ markSeen, setFlashMessage }, dispatch);
+// eslint-disable-next-line arrow-body-style
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ markSeen, setFlashMessage }, dispatch);
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(Bird);

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -6,11 +6,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { markSeen, setFlashMessage } from '../actions';
+
 import Modal from '../components/modal';
 import DetailsModal from '../components/details_modal';
 import Checkbox from '../components/checkbox';
 
+import { markSeen, setFlashMessage } from '../actions';
 import { dashify, nameContent } from '../utils';
 
 class Bird extends Component {
@@ -26,17 +27,17 @@ class Bird extends Component {
     this.handleMarkSeen = this.handleMarkSeen.bind(this);
   }
 
-  toggleSeenModal() {
-    this.setState({ showSeenModal: !this.state.showSeenModal });
+  handleMarkSeen() {
+    this.props.markSeen(this.props.scientific_name);
+    this.props.setFlashMessage("Bird marked as seen!");
   }
 
   toggleDetailsModal() {
     this.setState({ showDetailsModal: !this.state.showDetailsModal });
   }
 
-  handleMarkSeen() {
-    this.props.markSeen(this.props.scientific_name);
-    this.props.setFlashMessage("Bird marked as seen!");
+  toggleSeenModal() {
+    this.setState({ showSeenModal: !this.state.showSeenModal });
   }
 
   render() {

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -7,12 +7,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import { markSeen, setFlashMessage } from '../actions';
+import { dashify, nameContent } from '../utils';
+
 import Modal from '../components/modal';
 import DetailsModal from '../components/details_modal';
 import Checkbox from '../components/checkbox';
-
-import { markSeen, setFlashMessage } from '../actions';
-import { dashify, nameContent } from '../utils';
 
 class Bird extends Component {
   constructor(props) {

--- a/app/javascript/react_app/containers/bird.jsx
+++ b/app/javascript/react_app/containers/bird.jsx
@@ -1,8 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable react/prop-types */
-/* eslint-disable quotes */
-/* eslint-disable camelcase */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -29,7 +24,7 @@ class Bird extends Component {
 
   handleMarkSeen() {
     this.props.markSeen(this.props.scientific_name);
-    this.props.setFlashMessage("Bird marked as seen!");
+    this.props.setFlashMessage('Bird marked as seen!');
   }
 
   toggleDetailsModal() {

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -1,8 +1,3 @@
-/* eslint-disable no-restricted-globals */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -6,6 +6,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+
 import { fetchGroup, sortBirds } from '../actions';
 
 import Bird from './bird';

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -39,7 +39,7 @@ class BirdList extends Component {
 
   render() {
     const {
-      sortedBirds, totalSeen, totalBirds, englishName, scientificName, userLangPref, sortedBy
+      sortedBirds, totalSeen, totalBirds, englishName, scientificName, userLangPref, sortedBy,
     } = this.props;
 
     const title = englishName || scientificName || '...';

--- a/app/javascript/react_app/containers/flash_message.jsx
+++ b/app/javascript/react_app/containers/flash_message.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/javascript/react_app/containers/flash_message.jsx
+++ b/app/javascript/react_app/containers/flash_message.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+
 import { clearFlashMessage } from '../actions';
 
 class FlashMessage extends Component {

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -55,7 +55,7 @@ class GroupList extends Component {
         <SearchBar />
 
         <ul className="list-group mt-4">
-          <GroupHeader {...groupHeaderProps}/>
+          <GroupHeader {...groupHeaderProps} />
 
           {
             sortedGroups.map((group) => (

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -4,11 +4,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+
 import { fetchGroups, sortGroups, setGroupListScrollPos } from '../actions';
 
 import Group from '../components/group';
 import SearchBar from './search_bar';
-import GroupHeader from "../components/group_header";
+import GroupHeader from '../components/group_header';
 
 class GroupList extends Component {
   componentDidMount() {

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/javascript/react_app/containers/lifelist.jsx
+++ b/app/javascript/react_app/containers/lifelist.jsx
@@ -5,11 +5,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+
 import { fetchLifelist, sortLifelist } from '../actions';
+import { nameContent } from '../utils';
 
 import BackLink from '../components/back_link';
 import GroupHeader from '../components/group_header';
-import { nameContent } from '../utils';
 
 class Lifelist extends Component {
   componentDidMount() {

--- a/app/javascript/react_app/containers/lifelist.jsx
+++ b/app/javascript/react_app/containers/lifelist.jsx
@@ -1,7 +1,3 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable camelcase */
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/javascript/react_app/containers/search_bar.jsx
+++ b/app/javascript/react_app/containers/search_bar.jsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 import { Link } from 'react-router-dom';
 
 import { fetchSearchBirds, clearSearchBirds } from '../actions';
-import { hashify } from "../utils";
+import { hashify } from '../utils';
 
 class SearchBar extends Component {
   constructor() {

--- a/app/javascript/react_app/containers/search_bar.jsx
+++ b/app/javascript/react_app/containers/search_bar.jsx
@@ -9,12 +9,12 @@ import { fetchSearchBirds, clearSearchBirds } from '../actions';
 import { hashify } from '../utils';
 
 class SearchBar extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       showDropdown: false,
-      input: "",
+      input: '',
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -27,23 +27,23 @@ class SearchBar extends Component {
   }
 
   handleChange(event) {
-    const { fetchSearchBirds, langPref, popThreshold } = this.props;
+    const { langPref, popThreshold } = this.props;
     const input = event.target.value;
 
     this.state.input = input;
-    fetchSearchBirds(input, langPref, popThreshold);
-  };
+    this.props.fetchSearchBirds(input, langPref, popThreshold);
+  }
 
-  handleFocus(event) {
+  handleFocus() {
     this.setState({ showDropdown: true });
-  };
+  }
 
   handleBlur(event) {
     // don't hide dropdown if an anchor gets clicked
     if (!event.relatedTarget) {
       this.setState({ showDropdown: false });
     }
-  };
+  }
 
   render() {
     const { results, langPref } = this.props;
@@ -56,47 +56,48 @@ class SearchBar extends Component {
       order,
     }) => {
       const c = [];
-      let url = "";
+      let url = '';
 
-      c.push(
+      c.push((
         <p key={scientific_name}>
           <em>{scientific_name}</em>
         </p>
-      );
+      ));
 
-      if (langPref !== "se") {
+      if (langPref !== 'se') {
         c.push(<p key={english_name}>{english_name}</p>); // add english_name for en & both
       }
-      if (langPref !== "en") {
+      if (langPref !== 'en') {
         c.push(<p key={swedish_name}>{swedish_name}</p>); // add english_name for se & both
       }
 
-      if (this.props.groupByPref === "order") {
+      if (this.props.groupByPref === 'order') {
         url = `/orders/${order.scientific_name}`;
       } else {
         url = `/families/${family.scientific_name}`;
       }
-      
+
       const linkProps = {
         to: {
           pathname: url,
           hash: hashify(scientific_name),
-        }
-      }
+        },
+      };
 
       return <Link {...linkProps}><div>{c}</div></Link>;
     };
 
     const listItems = () => {
-      if (results.length === 0 && this.state.input.length > 0)
+      if (results.length === 0 && this.state.input.length > 0) {
         return <li><div><p>Sorry, no results</p></div></li>;
+      }
 
       return results.map((bird) => (
         <li key={bird.scientific_name}>{listItemContent(bird)}</li>
       ));
     };
 
-    const dropdownClasses = this.state.showDropdown ? "" : " d-none";
+    const dropdownClasses = this.state.showDropdown ? '' : ' d-none';
 
     return (
       <div id="search-bar-container">

--- a/app/javascript/react_app/containers/search_bar.jsx
+++ b/app/javascript/react_app/containers/search_bar.jsx
@@ -16,13 +16,17 @@ class SearchBar extends Component {
       showDropdown: false,
       input: "",
     };
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
   }
 
   componentDidMount() {
     this.props.clearSearchBirds();
   }
 
-  handleChange = (event) => {
+  handleChange(event) {
     const { fetchSearchBirds, langPref, popThreshold } = this.props;
     const input = event.target.value;
 
@@ -30,11 +34,11 @@ class SearchBar extends Component {
     fetchSearchBirds(input, langPref, popThreshold);
   };
 
-  handleFocus = (event) => {
+  handleFocus(event) {
     this.setState({ showDropdown: true });
   };
 
-  handleBlur = (event) => {
+  handleBlur(event) {
     // don't hide dropdown if an anchor gets clicked
     if (!event.relatedTarget) {
       this.setState({ showDropdown: false });

--- a/app/javascript/react_app/containers/search_bar.jsx
+++ b/app/javascript/react_app/containers/search_bar.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-/* eslint-disable react/prop-types */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -20,11 +20,12 @@ class Settings extends Component {
   }
 
   settingsChange(id, value) {
-    // do not need to force a re-render
-    const settingsCopy = { ...this.state.settings };
+    this.setState((prevState) => {
+      const copy = { ...prevState };
+      copy.settings[id] = value;
 
-    settingsCopy[id] = value;
-    this.setState({ settings: settingsCopy });
+      return copy;
+    });
   }
 
   saveSettings(event) {

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -12,9 +12,12 @@ class Settings extends Component {
 
     // setting defaults overriden with user settings
     this.state = { settings: props.settings }
+
+    this.settingsChange = this.settingsChange.bind(this);
+    this.saveSettings = this.saveSettings.bind(this);
   }
 
-  settingsChange = (id, value) => {
+  settingsChange(id, value) {
     // do not need to force a re-render
     const settingsCopy = { ...this.state.settings };
 
@@ -22,7 +25,7 @@ class Settings extends Component {
     this.setState({ settings: settingsCopy });
   }
 
-  saveSettings = (event) => {
+  saveSettings(event) {
     event.preventDefault();
     this.props.saveSettings(this.state.settings);
     this.props.setFlashMessage("Settings saved!");

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+
 import { saveSettings, setFlashMessage } from "../actions";
+
 import BackLink from "../components/back_link";
 
 class Settings extends Component {

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-/* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/app/javascript/react_app/containers/settings.jsx
+++ b/app/javascript/react_app/containers/settings.jsx
@@ -1,17 +1,19 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import { saveSettings, setFlashMessage } from "../actions";
+import { saveSettings, setFlashMessage } from '../actions';
 
-import BackLink from "../components/back_link";
+import BackLink from '../components/back_link';
 
 class Settings extends Component {
   constructor(props) {
     super(props);
 
     // setting defaults overriden with user settings
-    this.state = { settings: props.settings }
+    this.state = { settings: props.settings };
 
     this.settingsChange = this.settingsChange.bind(this);
     this.saveSettings = this.saveSettings.bind(this);
@@ -28,7 +30,7 @@ class Settings extends Component {
   saveSettings(event) {
     event.preventDefault();
     this.props.saveSettings(this.state.settings);
-    this.props.setFlashMessage("Settings saved!");
+    this.props.setFlashMessage('Settings saved!');
   }
 
   render() {
@@ -57,7 +59,7 @@ class Settings extends Component {
       <form onSubmit={this.saveSettings}>
         <h2>Settings:</h2>
 
-        <BackLink/>
+        <BackLink />
 
         <div className="form-check my-3">
           <input className="form-check-input" type="checkbox" checked={seenConfirmation} value={seenConfirmation} onChange={(event) => this.settingsChange('seenConfirmation', event.target.checked)} />
@@ -84,7 +86,7 @@ class Settings extends Component {
         <div className="form-group">
           <label className="mr-2">Population threshold:</label>
           <p><em>{populationText()}</em></p>
-          <input value={populationThreshold} min="5" max="9" type="range" className="form-range w-100 hover-pointer" onChange={(event) => this.settingsChange('populationThreshold', +event.target.value)}/>
+          <input value={populationThreshold} min="5" max="9" type="range" className="form-range w-100 hover-pointer" onChange={(event) => this.settingsChange('populationThreshold', +event.target.value)} />
         </div>
 
         <button type="submit" className="btn btn-primary">Submit</button>
@@ -97,6 +99,9 @@ const mapStateToProps = (state) => ({
   settings: state.settingsData,
 });
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({ saveSettings, setFlashMessage }, dispatch);
+// eslint-disable-next-line arrow-body-style
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators({ saveSettings, setFlashMessage }, dispatch);
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(Settings);


### PR DESCRIPTION
This PR consists off cleaning up style errors and changing class arrow functions to regular functions with binding if necessary. The latter was an important change because of two reasons:
1. Arrow functions get pushed to the constructor method by babel and are not available in the prototype of the class unlike regular class methods/functions. This means for arrow functions the function needs to be created for each instance of the class, thus reducing performance. You can read more [here](https://medium.com/@charpeni/arrow-functions-in-class-properties-might-not-be-as-great-as-we-think-3b3551c440b1).
2. Arrow functions for class methods are unrecognised by eslint and therefore the style check would always break at the equals after the   function name due to `unexpected symbol`. The breaking of eslint check made it more difficult to keep code consistent.

Temporary eslint disables such as prop types have been moved from as entire file disables to the eslint config. Issue cards should be made for each that should be removed and fixed in the future.
