### PR TITLE
Fix/scrolling bug on every birdlist component update

### DIFF
--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -17,18 +17,21 @@ class BirdList extends Component {
   }
 
   componentDidUpdate() {
-    const { hash } = this.props.location;
+    if (!this.hasScrolled) {
+      const { hash } = this.props.location;
 
-    if (hash !== '') {
-      const e = document.getElementById(hash.slice(1));
+      if (hash !== '') {
+        const e = document.getElementById(hash.slice(1));
 
-      if (e) {
-        const header = document.getElementById('group-header');
-        const headerHeight = header ? header.getBoundingClientRect().height : 0;
+        if (e) {
+          const header = document.getElementById('group-header');
+          const headerHeight = header ? header.getBoundingClientRect().height : 0;
 
-        const yPos = e.getBoundingClientRect().top - headerHeight;
+          const yPos = e.getBoundingClientRect().top - headerHeight;
 
-        window.scrollTo(0, yPos);
+          window.scrollTo(0, yPos);
+          this.hasScrolled = true;
+        }
       }
     }
   }


### PR DESCRIPTION
Before this fix, the bird list would scroll to a bird component
if there was a given hash in the url everytime the birdlist
was updated. Such as the list being reordered.

This commit adds stae.hasScrolled so that the scroll will only
occur once, after the new birds have been received.