### PR TITLE
Add OptionsBar component

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,6 +1,6 @@
 .alert {
   position: fixed;
-  bottom: 16px;
+  bottom: 48px;
   right: 16px;
   z-index: 80;
   background-color: $primary;

--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -7,7 +7,7 @@ footer {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 20px;
+  padding: 20px 20px 30px 20px; // extra bottom padding for options bar
 
   p {
     margin-bottom: 0;

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -12,3 +12,4 @@
 @import "page_title";
 @import "button";
 @import "form";
+@import "options_bar";

--- a/app/assets/stylesheets/components/_options_bar.scss
+++ b/app/assets/stylesheets/components/_options_bar.scss
@@ -1,0 +1,27 @@
+#options-bar {
+  display: flex;
+  position: fixed;
+  align-items: center;
+  min-height: fit-content !important;
+  width: 100%;
+  left:0;
+  bottom: -1px;
+  z-index: 40;
+  padding: 4px 15px 4px 15px;
+  background-color: $primary !important;
+
+  @include media-breakpoint-up(sm) {
+    padding: 4px 30px 4px 30px;
+  }
+  &, a {
+    color: #fff;
+  }
+  p {
+    margin: 0;
+
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  }
+}

--- a/app/javascript/react_app/components/options_bar.jsx
+++ b/app/javascript/react_app/components/options_bar.jsx
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+
+import BackLink from './back_link';
+
+class OptionsBar extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showOptionsBar: false,
+    };
+
+    this.handleScroll = this.handleScroll.bind(this);
+  }
+
+  componentDidMount() {
+    window.addEventListener('scroll', this.handleScroll, true);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.handleScroll);
+  }
+
+  static handleGoUpClick() {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+  }
+
+  handleScroll() {
+    const { showOptionsBar } = this.state;
+    const hasScrollDown = window.scrollY > 80;
+
+    // check showOptionsBar to avoid unnecessary setStates
+    if (hasScrollDown && !showOptionsBar) {
+      this.setState({ showOptionsBar: true });
+    } else if (!hasScrollDown && showOptionsBar) {
+      this.setState({ showOptionsBar: false });
+    }
+  }
+
+  render() {
+    const { backLinkProps } = this.props;
+    const { showOptionsBar } = this.state;
+
+    return (
+      showOptionsBar && (
+        <div key="options-bar" id="options-bar">
+          { backLinkProps && <BackLink {...backLinkProps} /> }
+
+          <p className="ml-auto" onClick={OptionsBar.handleGoUpClick}>Go Up</p>
+        </div>
+      )
+    );
+  }
+}
+
+export default OptionsBar;

--- a/app/javascript/react_app/containers/bird_list.jsx
+++ b/app/javascript/react_app/containers/bird_list.jsx
@@ -8,6 +8,7 @@ import Bird from './bird';
 import BackLink from '../components/back_link';
 import GroupHeader from '../components/group_header';
 import PageTitle from '../components/page_title';
+import OptionsBar from '../components/options_bar';
 
 class BirdList extends Component {
   componentDidMount() {
@@ -60,10 +61,15 @@ class BirdList extends Component {
       totalAmount: totalBirds,
     };
 
+    const backLinkProps = {
+      to: '/',
+    };
+
     return (
       <>
         <PageTitle {...titleProps} />
-        <BackLink to="/" />
+        <BackLink {...backLinkProps} />
+        <OptionsBar backLinkProps={backLinkProps} />
 
         <ul className="list-group mt-3">
           <GroupHeader {...groupHeaderProps} />

--- a/app/javascript/react_app/containers/group_list.jsx
+++ b/app/javascript/react_app/containers/group_list.jsx
@@ -9,6 +9,7 @@ import Group from '../components/group';
 import SearchBar from './search_bar';
 import GroupHeader from '../components/group_header';
 import PageTitle from '../components/page_title';
+import OptionsBar from '../components/options_bar';
 
 class GroupList extends Component {
   componentDidMount() {
@@ -53,6 +54,7 @@ class GroupList extends Component {
       <>
         <PageTitle {...titleProps} />
         <SearchBar />
+        <OptionsBar />
 
         <ul className="list-group mt-4">
           <GroupHeader {...groupHeaderProps} />

--- a/app/javascript/react_app/containers/lifelist.jsx
+++ b/app/javascript/react_app/containers/lifelist.jsx
@@ -6,6 +6,7 @@ import { fetchLifelist, sortLifelist } from '../actions';
 import { nameContent } from '../utils';
 
 import BackLink from '../components/back_link';
+import OptionsBar from '../components/options_bar';
 import GroupHeader from '../components/group_header';
 
 class Lifelist extends Component {
@@ -34,11 +35,16 @@ class Lifelist extends Component {
       ],
     };
 
+    const backLinkProps = {
+      to: '/',
+    };
+
     return (
       <>
         <h1>Lifelist</h1>
 
-        <BackLink to="/" />
+        <BackLink {...backLinkProps} />
+        <OptionsBar backLinkProps={backLinkProps} />
 
         <ol className="list-group mt-3">
           <GroupHeader {...groupHeaderProps} />


### PR DESCRIPTION
This component is fixed to the bottom of the screen with 100% width. It appears when you scroll down the page a bit. It must be added to each page component that you want it on.

The component has two functionalities: Go to the top of the page and go back. The top functionality is always there, while the go back is optional depending on whether the component receives props for the backlink. The backLinkProps only requires a `to` key which has a value of the path that you want the back link to point to.

Other changes:
- Increased footer bottom padding
- Increased Alert/FlashMessage bottom