### PR TITLE
Skip CircleCI if PR is only documentation changes

### DIFF
--- a/.circleci/bin/halt-for-documentation-only-changes.sh
+++ b/.circleci/bin/halt-for-documentation-only-changes.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+CHANGED_FILES=$(git show --name-only --pretty="" $CIRCLE_SHA1)
+if $(grep -qvE '(\.(md)$)' <<< $CHANGED_FILES) ; then
+  exit 1
+fi
+echo "Only documentation was updated, stopping build!"
+exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
           POSTGRES_DB: swedish-birds_test
 
     steps:
+      - run: .circleci/bin/halt-for-documentation-only-changes.sh && circleci step halt || true
       - checkout
       - restore_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Unnecessary to run test checks if the changes were only for documentation.