### PR TITLE
Temporarily disable Dependabot bumping yarn packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,6 @@ updates:
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "daily"


### PR DESCRIPTION
There's currently no tests for the frontend-side, so bumping yarn
packages is too risky.