### PR TITLE
move modal body and footer out from Modal component

### DIFF
--- a/app/javascript/react_app/components/bird/bird.jsx
+++ b/app/javascript/react_app/components/bird/bird.jsx
@@ -21,11 +21,17 @@ class Bird extends Component {
     this.toggleSeenModal = this.toggleSeenModal.bind(this);
     this.toggleDetailsModal = this.toggleDetailsModal.bind(this);
     this.handleMarkSeen = this.handleMarkSeen.bind(this);
+    this.handleConfirm = this.handleConfirm.bind(this);
   }
 
   handleMarkSeen() {
     this.props.markSeen(this.props.scientific_name);
     this.props.setFlashMessage('Bird marked as seen!');
+  }
+
+  handleConfirm() {
+    this.handleMarkSeen();
+    this.toggleSeenModal();
   }
 
   toggleDetailsModal() {
@@ -62,8 +68,18 @@ class Bird extends Component {
 
         {
           this.state.showSeenModal && (
-            <Modal title="Confirm sighting" confirmButtonText="Confirm" close={this.toggleSeenModal} action={this.handleMarkSeen}>
-              <p>Are you sure you want to mark this bird as seen? This cannot be reversed.</p>
+            <Modal title="Confirm sighting" close={this.toggleSeenModal}>
+              <div className="modal-body">
+                <p>Are you sure you want to mark this bird as seen? This cannot be reversed.</p>
+              </div>
+              <div className="modal-footer">
+                <button type="button" className="btn btn-primary hover-pointer" onClick={this.handleConfirm}>
+                  Confirm
+                </button>
+                <button type="button" className="btn btn-dark hover-pointer" onClick={this.toggleSeenModal}>
+                  Close
+                </button>
+              </div>
             </Modal>
           )
         }

--- a/app/javascript/react_app/components/bird/details_modal.jsx
+++ b/app/javascript/react_app/components/bird/details_modal.jsx
@@ -11,7 +11,7 @@ const DetailsModal = ({ close }) => {
 
   return (
     <Modal title="Detail shorthand" close={close}>
-      <div className="detailsModalContent">
+      <div className="detailsModalContent modal-body">
         <p><em>Information is regarding to Sweden</em></p>
 
         <div className="contentGroup">

--- a/app/javascript/react_app/components/bird/modal.jsx
+++ b/app/javascript/react_app/components/bird/modal.jsx
@@ -2,13 +2,8 @@ import React from 'react';
 
 const Modal = (props) => {
   const {
-    title, confirmButtonText, action, close, children,
+    title, close, children,
   } = props;
-
-  const handleClick = () => {
-    action();
-    close();
-  };
 
   const checkBackdropClick = (event) => {
     if (event.target === event.currentTarget) close();
@@ -24,21 +19,7 @@ const Modal = (props) => {
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
-          <div className="modal-body">
-            {children}
-          </div>
-          <div className="modal-footer">
-            {
-              action && (
-                <button type="button" className="btn btn-primary hover-pointer" onClick={handleClick}>
-                  {confirmButtonText}
-                </button>
-              )
-            }
-            <button type="button" className="btn btn-dark hover-pointer" onClick={close}>
-              Close
-            </button>
-          </div>
+          {children}
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Modal component** contains the header
If a modal body and footer are needed they need to be passed as children top the **Modal component**

Separate function called handleConfirm handles confirming observation when clicking button in modal

When we remove the choice whether a confirmation modal is wanted (separate PR), we can remove handleConfirm and only use handleMarkSeen with an addition of closing the modal in the end of handleMarkSeen
