### PR TITLE
Add note to Observation model and API controller

### DIFF
--- a/app/controllers/api/v1/observations_controller.rb
+++ b/app/controllers/api/v1/observations_controller.rb
@@ -13,12 +13,16 @@ class Api::V1::ObservationsController < Api::V1::BaseController
   def create
     return throw_error unless @bird
 
-    if Observation.create(bird: @bird, user: current_user)
+    observation = Observation.new(bird: @bird, user: current_user, note: observation_params[:note])
+
+    if observation.save
       render json: {
                     bird_scientific_name: @bird.scientific_name,
                     bird_order_scientific_name: @bird.family.order.scientific_name,
                     bird_family_scientific_name: @bird.family.scientific_name,
-                    seen: true }
+                    note: observation.note,
+                    seen: true
+                  }
     else
       throw_error
     end
@@ -32,5 +36,9 @@ class Api::V1::ObservationsController < Api::V1::BaseController
 
   def set_bird
     @bird = Bird.find_by(scientific_name: params[:bird_id].capitalize)
+  end
+
+  def observation_params
+    params.permit(:note)
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -3,4 +3,12 @@ class Observation < ApplicationRecord
 
   belongs_to :bird
   belongs_to :user
+
+  before_save :nullify_blank_notes
+
+  private
+
+  def nullify_blank_notes
+    self.note = note.presence
+  end
 end

--- a/db/migrate/20220322171437_add_note_to_observations.rb
+++ b/db/migrate/20220322171437_add_note_to_observations.rb
@@ -1,0 +1,5 @@
+class AddNoteToObservations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :observations, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_01_111807) do
+ActiveRecord::Schema.define(version: 2022_03_22_171437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2021_06_01_111807) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "note"
     t.index ["bird_id"], name: "index_observations_on_bird_id"
     t.index ["user_id"], name: "index_observations_on_user_id"
   end

--- a/test/controllers/api/v1/observations_controller_test.rb
+++ b/test/controllers/api/v1/observations_controller_test.rb
@@ -19,12 +19,24 @@ class Api::V1::ObservationControllerTest < ActionDispatch::IntegrationTest
 
   test 'POST #create successfully creates an observation for the logged in user' do
     sign_in @user
+    note = 'First observation notes'
+
+    assert_difference('@user.observations.count', 1) do
+      post api_v1_bird_observations_url(@bird_id, params: { note: note })
+    end
+    assert_response :success
+    expected = { 'bird_scientific_name'=> 'Neo', 'bird_order_scientific_name'=> 'Passeriformes', 'bird_family_scientific_name'=> 'Paridae', 'note'=>note, 'seen'=> true }
+    assert_equal(expected, json_response)
+  end
+
+  test 'POST #create successfully creates an observation even without a given note' do
+    sign_in @user
 
     assert_difference('@user.observations.count', 1) do
       post api_v1_bird_observations_url(@bird_id)
     end
     assert_response :success
-    expected = { 'bird_scientific_name'=> 'Neo', 'bird_order_scientific_name'=> 'Passeriformes', 'bird_family_scientific_name'=> 'Paridae', 'seen'=> true }
+    expected = { 'bird_scientific_name'=> 'Neo', 'bird_order_scientific_name'=> 'Passeriformes', 'bird_family_scientific_name'=> 'Paridae', 'note'=>nil, 'seen'=> true }
     assert_equal(expected, json_response)
   end
 

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class ObservationTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:ryan)
+    @bird = birds(:azure_tit)
+  end
+
+  test 'an actual note get correctly saved' do
+    note = 'First observation note'
+    observation = @user.observations.new(bird: @bird, note: note)
+
+    assert_difference('@user.observations.count', 1) do
+      observation.save
+    end
+    assert_equal(note, observation.note)
+  end
+
+  test 'observation can be saved without a note' do
+    observation = @user.observations.new(bird: @bird)
+
+    assert_difference('@user.observations.count', 1) do
+      observation.save
+    end
+  end
+
+  test "note gets saved as nil when it's nil" do
+    note = nil
+    observation = @user.observations.new(bird: @bird, note: note)
+
+    assert_difference('@user.observations.count', 1) do
+      observation.save
+    end
+    assert_nil(observation.note)
+  end
+
+  test "note gets saved as nil when it's an empty string" do
+    note = ''
+    observation = @user.observations.new(bird: @bird, note: note)
+
+    assert_difference('@user.observations.count', 1) do
+      observation.save
+    end
+    assert_nil(observation.note)
+  end
+end


### PR DESCRIPTION
Add option Observation note to the model as well as make the API support the attribute.

Saves the given note to the observation if given, but also works if not,
so it supports the current frontend API requests which currently has
no note frontend input.