### PR TITLE
Add observed_at to Observation and API controller

### DIFF
--- a/app/controllers/api/v1/observations_controller.rb
+++ b/app/controllers/api/v1/observations_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::ObservationsController < Api::V1::BaseController
   def create
     return throw_error unless @bird
 
-    observation = Observation.new(bird: @bird, user: current_user, note: observation_params[:note])
+    observation = Observation.new(bird: @bird, user: current_user, note: observation_params[:note], observed_at: observation_params[:observed_at])
 
     if observation.save
       render json: {
@@ -21,17 +21,18 @@ class Api::V1::ObservationsController < Api::V1::BaseController
                     bird_order_scientific_name: @bird.family.order.scientific_name,
                     bird_family_scientific_name: @bird.family.scientific_name,
                     note: observation.note,
+                    observed_at: observation.observed_at,
                     seen: true
                   }
     else
-      throw_error
+      throw_error(error: observation.errors.full_messages.join)
     end
   end
 
   private
 
-  def throw_error
-    render json: { error: "Bad request" }, status: :bad_request
+  def throw_error(error: 'Bad request')
+    render json: { error: error }, status: :bad_request
   end
 
   def set_bird
@@ -39,6 +40,6 @@ class Api::V1::ObservationsController < Api::V1::BaseController
   end
 
   def observation_params
-    params.permit(:note)
+    params.permit(:note, :observed_at)
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,14 +1,21 @@
 class Observation < ApplicationRecord
   validates :bird, uniqueness: [scope: :user, message: 'User can only add an observation for a bird species once.']
+  validates :observed_at, presence: { message: 'must be a Date or zero.' }
 
   belongs_to :bird
   belongs_to :user
 
-  before_save :nullify_blank_notes
+  before_save :nullify_blank_notes, :format_unknown_observed_at
+
+  UNKNOWN_OBSERVED_AT_VALUE = 0
 
   private
 
   def nullify_blank_notes
     self.note = note.presence
+  end
+
+  def format_unknown_observed_at
+    self.observed_at = nil if observed_at == UNKNOWN_OBSERVED_AT_VALUE
   end
 end

--- a/db/migrate/20220326100315_add_observed_at_to_observation.rb
+++ b/db/migrate/20220326100315_add_observed_at_to_observation.rb
@@ -1,0 +1,12 @@
+class AddObservedAtToObservation < ActiveRecord::Migration[6.1]
+  def up
+    add_column :observations, :observed_at, :date
+
+    Observation.find_each do |observation|
+      observation.update(observed_at: observation.created_at)
+    end
+  end
+
+  # No down method is implemented because observed_at and created_at times may differ
+  # and so we should be careful in deleting (losing) this data of an observation.
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_22_171437) do
+ActiveRecord::Schema.define(version: 2022_03_26_100315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2022_03_22_171437) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "note"
+    t.date "observed_at"
     t.index ["bird_id"], name: "index_observations_on_bird_id"
     t.index ["user_id"], name: "index_observations_on_user_id"
   end

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -6,9 +6,36 @@ class ObservationTest < ActiveSupport::TestCase
     @bird = birds(:azure_tit)
   end
 
+  test 'cannot be saved without observed_at' do
+    observation = @user.observations.new(bird: @bird, note: 'note')
+
+    assert_equal(false, observation.save)
+    assert_includes(observation.errors.full_messages, 'Observed at must be a Date or zero.')
+  end
+
+  test 'a string date gets correctly corrected for observed_at' do
+    observed_at = '26/03/2022'
+    observation = @user.observations.new(bird: @bird, note: 'note', observed_at: observed_at)
+
+    assert_difference('@user.observations.count', 1) do
+      observation.save
+    end
+    assert_equal(Date, observation.observed_at.class)
+  end
+
+  test 'observed_at gets saved as nil when 0' do
+    observed_at = 0
+    observation = @user.observations.new(bird: @bird, note: 'note', observed_at: observed_at)
+
+    assert_difference('@user.observations.count', 1) do
+      observation.save
+    end
+    assert_nil(observation.observed_at)
+  end
+
   test 'an actual note get correctly saved' do
     note = 'First observation note'
-    observation = @user.observations.new(bird: @bird, note: note)
+    observation = @user.observations.new(bird: @bird, note: note, observed_at: Date.today)
 
     assert_difference('@user.observations.count', 1) do
       observation.save
@@ -17,7 +44,7 @@ class ObservationTest < ActiveSupport::TestCase
   end
 
   test 'observation can be saved without a note' do
-    observation = @user.observations.new(bird: @bird)
+    observation = @user.observations.new(bird: @bird, observed_at: Date.today)
 
     assert_difference('@user.observations.count', 1) do
       observation.save
@@ -26,7 +53,7 @@ class ObservationTest < ActiveSupport::TestCase
 
   test "note gets saved as nil when it's nil" do
     note = nil
-    observation = @user.observations.new(bird: @bird, note: note)
+    observation = @user.observations.new(bird: @bird, note: note, observed_at: Date.today)
 
     assert_difference('@user.observations.count', 1) do
       observation.save
@@ -36,7 +63,7 @@ class ObservationTest < ActiveSupport::TestCase
 
   test "note gets saved as nil when it's an empty string" do
     note = ''
-    observation = @user.observations.new(bird: @bird, note: note)
+    observation = @user.observations.new(bird: @bird, note: note, observed_at: Date.today)
 
     assert_difference('@user.observations.count', 1) do
       observation.save


### PR DESCRIPTION
When support is added to the frontend, this will allow the user to save
a date that differs from the day they are creating it. Meaning, they
can for example, do it the day after or even make observation records
for dates for the distant past.

There will be a scenario where the user wants to create an observation
but does not know when they observed the bird at. For this, we should
pass 0 to the API so that the record gets saved as nil. (The db only
supports nil/NULL and dates).

The reason we want to pass 0 instead of nil, is so that the API
explicitly has to delare that the date is unknown, preventing accidental
requests without the observed at (nil).