### PR TITLE
Fix Observation uniqueness scope to user validation

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,5 +1,5 @@
 class Observation < ApplicationRecord
-  validates :bird, uniqueness: [scope: :user, message: 'User can only add an observation for a bird species once.']
+  validates :bird, uniqueness: { scope: :user, message: 'can only have one observation per user.' }
   validates :observed_at, presence: { message: 'must be a Date or zero.' }
 
   belongs_to :bird

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,3 +1,6 @@
 ryan:
   id: 1
   email: contact@ryanofwoods.com
+sara:
+  id: 2
+  email: saralotfi@swedishbirds.com

--- a/test/models/observation_test.rb
+++ b/test/models/observation_test.rb
@@ -3,7 +3,26 @@ require 'test_helper'
 class ObservationTest < ActiveSupport::TestCase
   setup do
     @user = users(:ryan)
+    @other_user = users(:sara)
     @bird = birds(:azure_tit)
+    @valid_attributes = { bird: @bird, note: 'note', observed_at: '26/03/2022' }
+  end
+
+  test 'a user cannot have two observations for one bird' do
+    observation = @user.observations.new(@valid_attributes)
+    assert_equal(true, observation.save)
+
+    observation = @user.observations.new(@valid_attributes)
+    assert_equal(false, observation.save)
+    assert_includes(observation.errors.full_messages, 'Bird can only have one observation per user.')
+  end
+
+  test 'users can each have an observation for the same bird.' do
+    observation = @user.observations.new(@valid_attributes)
+    assert_equal(true, observation.save)
+
+    other_observation = @other_user.observations.new(@valid_attributes)
+    assert_equal(true, other_observation.save)
   end
 
   test 'cannot be saved without observed_at' do


### PR DESCRIPTION
The uniqueness validation was being given an array instead of a hash,
which caused the scope to not work correctly.