### PR TITLE
Make webpack-cli yarn package available to all environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
     "redux-promise": "^0.6.0",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "webpack-cli": "^4.9.2"
   },
   "version": "0.1.0",
   "devDependencies": {
@@ -38,7 +39,6 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "ts-standard": "^11.0.0",
     "typescript": "^4.6.3",
-    "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Seems compilation was failing on production...

```
Compiling...
Compiled all packs in /app/public/packs
One CLI for webpack must be installed. These are recommended choices, delivered as separate packages:
 - webpack-cli (https://github.com/webpack/webpack-cli)
   The original webpack full-featured CLI.
We will use "yarn" to install the CLI via "yarn add -D".
Do you want to install 'webpack-cli' (yes/no): 
```

