### PR TITLE
Fix radio button not show selected radio on load

### DIFF
--- a/app/javascript/beta_app/components/shared/filter_radio_button.tsx
+++ b/app/javascript/beta_app/components/shared/filter_radio_button.tsx
@@ -17,6 +17,8 @@ const FilterRadioButton = <T extends RadioValue>(props: FilterRadioButtonProps<T
     onChangeHandler(value)
   }
 
+  const isSelected = value === selectedRadio
+
   return (
     <div className='radio-item'>
       <input
@@ -25,7 +27,8 @@ const FilterRadioButton = <T extends RadioValue>(props: FilterRadioButtonProps<T
         type='radio'
         role='radio'
         name={name}
-        aria-checked={value === selectedRadio}
+        checked={isSelected}
+        aria-checked={isSelected}
         onChange={onRadioChange}
       />
       <label className='form-check-label' htmlFor={String(value)}>


### PR DESCRIPTION
The custom checked CSS styling for the label has a selector for if the
input is checked. Therefore, this change is necessary so the that the
default selected radio shows on load, and not only for when the radio
inputs are clicked (changed value).