### PR TITLE
Change Bird scope to exclude non-occurring birds

### DIFF
--- a/app/models/bird.rb
+++ b/app/models/bird.rb
@@ -5,6 +5,8 @@ class Bird < ApplicationRecord
   belongs_to :family
   has_many :observations
 
+  default_scope { where.not(population_category: 0) }
+
   include PgSearch::Model
   pg_search_scope :search_by_english_and_scientific_name,
                   against: [:scientific_name, :english_name],

--- a/test/fixtures/birds.yml
+++ b/test/fixtures/birds.yml
@@ -14,6 +14,14 @@ greylag_goose:
   family_id: 1
   details: Hf 3
   population_category: 3
+white_winged_scoter:
+  id: 44
+  scientific_name: Melanitta deglandi
+  english_name: White-winged Scoter
+  swedish_name: Amerikansk Knölsvärta
+  family_id: 1
+  details: '-'
+  population_category: 0
 pygmy_owl:
   id: 295
   scientific_name: Glaucidium passerinum

--- a/test/models/bird_test.rb
+++ b/test/models/bird_test.rb
@@ -24,6 +24,12 @@ class BirdTest < ActiveSupport::TestCase
     assert_includes(actual, expected)
   end
 
+  test '.all does not include birds with a population category of nil (never seen in Sweden)' do
+    non_occuring_bird = birds(:white_winged_scoter)
+    actual = Bird.all
+    refute_includes(actual, non_occuring_bird)
+  end
+
   test '.search_by_name searches by English name when given the language preference of "EN"' do
     actual = Bird.search_by_name('tit', 'EN', 7)
 


### PR DESCRIPTION
Some birds have been added to the database that has never been seen in
Sweden. These birds have a population category of 0 and should be
excluded from being used in the app. The best way to do this is through
a default scope so that they are consistently excluded from all SQL
calls.