### PR TITLE
fix onClick checkbox error in console

### DIFF
--- a/app/javascript/beta_app/components/bird/checkbox.tsx
+++ b/app/javascript/beta_app/components/bird/checkbox.tsx
@@ -4,7 +4,7 @@ interface CheckboxProps {
   classes: string
   checked: boolean
   id: string
-  onClick: () => void
+  onChange: () => void
   showDateHandler: () => void
 }
 
@@ -17,7 +17,7 @@ const Checkbox: React.FC<CheckboxProps> = (props) => {
   // Setting didMount to true upon mounting
   useEffect(() => { setDidMount(true) }, [])
 
-  const { checked, onClick, classes, showDateHandler } = props
+  const { checked, onChange, classes, showDateHandler } = props
   let newClasses = `${classes} checkbox-beta`
   newClasses += (animateClass) ? ' animate' : ''
   newClasses += (fadeClass) ? ' fadeaway' : ''
@@ -25,7 +25,7 @@ const Checkbox: React.FC<CheckboxProps> = (props) => {
   const newCheckboxProps = {
     type: 'checkbox',
     className: newClasses,
-    onClick,
+    onChange,
     checked
   }
 

--- a/app/javascript/beta_app/components/bird/checkbox_and_date.tsx
+++ b/app/javascript/beta_app/components/bird/checkbox_and_date.tsx
@@ -41,7 +41,7 @@ const CheckboxAndDate: React.FC<CheckboxAndDateProps> = ({ bird, toggleSeenModal
     classes: 'checkbox-checked-hover-pointer-none checkbox-beta',
     checked: bird.seen,
     id: bird.scientificName,
-    onClick: toggleSeenModal
+    onChange: toggleSeenModal
   }
 
   const showDateHandler = (): void => {


### PR DESCRIPTION
Fix error in console for mark-seen-checkboxes. OnClick changed to OnChange.

The error in console was: 
`You provided a 'checked' prop to a form field without an 'onChange' handler. This will render a read-only field. If the field should be mutable use 'defaultChecked'. Otherwise, set either 'onChange' or 'readOnly'.`