### PR TITLE
Change non-occurring birds' population category from nil to zero

### DIFF
--- a/db/migrate/20220502070213_change_non_occurring_birds_population_category_to_zero.rb
+++ b/db/migrate/20220502070213_change_non_occurring_birds_population_category_to_zero.rb
@@ -1,0 +1,9 @@
+class ChangeNonOccurringBirdsPopulationCategoryToZero < ActiveRecord::Migration[6.1]
+  def up
+    Bird.unscoped.where(population_category: nil).update_all(population_category: 0)
+  end
+
+  def down
+    Bird.unscoped.where(population_category: 0).update_all(population_category: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_26_100315) do
+ActiveRecord::Schema.define(version: 2022_05_02_070213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"


### PR DESCRIPTION
Some birds are in the database which do not occur in Sweden. These had
a population category of nil. Because of this, it was preventing a
presence validator. Also, in the future, we will adapt the Bird default
scope to exclude these birds, and in-conjuction with not having a
presence validator, it would be confusing to forget to set the category
and then not be able to find the Bird (due to the default scope).

It is also better that to have to set the population_category to a value
that has a special meaning, rather than it being the default.