### PR TITLE
Remove old react_app API routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,20 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
 
   namespace :api, defaults: { format: :json } do
-    namespace :v1 do
-      get '/groups', to: 'groups#index'
-      get 'birds/search', to: 'birds#search'
-
-      resources :families, only: [:show]
-      resources :orders, only: [:show]
-
-      resources :observations, only: [:index]
-
-      resources :birds, only: [] do
-        resources :observations, only: [:create]
-      end
-    end
-
     namespace :beta do
       get '/search', to: 'search#index'
 


### PR DESCRIPTION
These routes are no longer used and were not deleted when the react_app
was.