### PR TITLE
Fix search filter bug when no birds were found

### DIFF
--- a/app/javascript/react_app/helpers/filter_birds.test.ts
+++ b/app/javascript/react_app/helpers/filter_birds.test.ts
@@ -6,7 +6,8 @@ const initialFilters: BirdFilters = {
   searchScope: [],
   seenScope: 'all',
   orderScientificNameScope: null,
-  familyScientificNameScope: null
+  familyScientificNameScope: null,
+  searchValue: ''
 }
 
 const initialBirds: BirdWithOrWithoutObservation[] = [
@@ -36,6 +37,14 @@ test('when the searchScope is not empty, it filters the birds appropriately', ()
   const expected = [blueTit, greatTit]
   const actual = filterBirds({ birds, filters })
   expect(actual).toEqual(expected)
+})
+
+test('when the searchScope is empty because the search query results in no birds, it returns no birds', () => {
+  filters.searchScope = []
+  filters.searchValue = 'no bird has this name'
+
+  const actual = filterBirds({ birds, filters })
+  expect(actual).toEqual([])
 })
 
 test('when seenScope is "seen" it returns only seen birds', () => {

--- a/app/javascript/react_app/helpers/filter_birds.ts
+++ b/app/javascript/react_app/helpers/filter_birds.ts
@@ -7,6 +7,8 @@ interface Options {
 
 const filterBirds = ({ birds, filters }: Options): BirdWithOrWithoutObservation[] => {
   const { searchScope, seenScope, familyScientificNameScope, orderScientificNameScope } = filters
+  if (filters.searchScope.length === 0 && filters.searchValue.length > 0) return []
+
   return birds.filter(bird => {
     if (searchScope.length > 0) {
       if (!searchScope.includes(bird.scientificName)) return false


### PR DESCRIPTION
The filterBirds helper was treating an empty searchScope (result of
the search query), as no search has been done, so ignore this filter and
only filter by other filters. The problem was, that it meant that if
someone typed a query that resulted in no birds, it would then ignore
the searchScope, resulting in birds still being shown.

To prevent this, we'll return an empty array when a search query is set
and the search result (searchScope) was an empty array.

Note, we could do this check in the iterator, however, this is
unnecessary and prevents a possible 500 interator checks.