### PR TITLE
Remove temporary 0 limit on yarn dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,5 @@ updates:
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    open-pull-requests-limit: 0
     schedule:
       interval: "daily"


### PR DESCRIPTION
Allow for yarn package bumps. The limit will now default to 5.