### PR TITLE
Move modal with react createportal to root of DOM

### DIFF
--- a/app/javascript/react_app/components/shared/modal.tsx
+++ b/app/javascript/react_app/components/shared/modal.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import ReactPortal from './react_portal'
+
 interface ModalProps {
   title: string
   close: () => void
@@ -16,19 +18,21 @@ const Modal: React.FC<ModalProps> = (props) => {
   }
 
   return (
-    <div className='modal-component-backdrop' onClick={checkBackdropClick}>
-      <div className='modal-component'>
-        <div className='modal-content'>
-          <div className='modal-header'>
-            <h3 className='modal-title'>{title}</h3>
-            <button type='button' className='close' aria-label='Close' onClick={close}>
-              <span aria-hidden='true'>&times;</span>
-            </button>
+    <ReactPortal wrapperId='modal-container'>
+      <div className='modal-component-backdrop' onClick={checkBackdropClick}>
+        <div className='modal-component'>
+          <div className='modal-content'>
+            <div className='modal-header'>
+              <h3 className='modal-title'>{title}</h3>
+              <button type='button' className='close' aria-label='Close' onClick={close}>
+                <span aria-hidden='true'>&times;</span>
+              </button>
+            </div>
+            {children}
           </div>
-          {children}
         </div>
       </div>
-    </div>
+    </ReactPortal>
   )
 }
 

--- a/app/javascript/react_app/components/shared/react_portal.tsx
+++ b/app/javascript/react_app/components/shared/react_portal.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+interface ReactPortalProps {
+  children: React.ReactNode
+  wrapperId: string
+}
+
+const ReactPortal: React.FC<ReactPortalProps> = ({ children, wrapperId }) => {
+  const portalDiv = document.getElementById(wrapperId) as HTMLElement
+
+  return ReactDOM.createPortal(children, portalDiv)
+}
+
+export default ReactPortal

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,8 @@
     <div id="page-container">
       <div id="navbar-container">
       </div>
+      <div id="modal-container">
+      </div>
       
       <div id="content-container">
         <div class="container my-5">


### PR DESCRIPTION
- Created a separate component, ReactPortal, that acts as a wrapper and can be used by any component that wants to create a portal
- The Modal component now uses the ReactPortal component and is therefor "moved" to the root of the body