### PR TITLE
Reorder filters

### DIFF
--- a/app/javascript/react_app/components/filters/filter_group.tsx
+++ b/app/javascript/react_app/components/filters/filter_group.tsx
@@ -24,9 +24,9 @@ const FilterGroup: React.FC = () => {
 
   return (
     <>
-      <SearchBar searchValue={searchValue} />
       <SeenBirdsFilter selectedValue={selectedSeenValue} />
       <FamilyAndOrderFilter orders={orders} families={families} userSettings={userSettings} selectedOrderOption={selectedOrderOption} selectedFamilyOption={selectedFamilyOption} />
+      <SearchBar searchValue={searchValue} />
       <div className='d-flex justify-content-end'>
         <a id='reset-filter' href='' onClick={handleReset}>Reset filters</a>
       </div>


### PR DESCRIPTION
When on mobile, having the search bar at the top means that you cannot see the filtered birds without scrolling down. Instead, having the search bar at the bottom means you can see the effects of searching immediately, improving UX.