### PR TITLE
Make Order and Family filter on the same row

### DIFF
--- a/app/assets/stylesheets/components/_family_and_order_filter.scss
+++ b/app/assets/stylesheets/components/_family_and_order_filter.scss
@@ -1,0 +1,9 @@
+#filter-selects {
+  display: flex;
+  .form-group {
+    width: 50%;
+    &:first-child {
+      margin-right: 0.75rem;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -18,3 +18,4 @@
 @import "counter";
 @import "sorting_header";
 @import "reset_filter";
+@import "family_and_order_filter";

--- a/app/javascript/react_app/components/filters/family_and_order_filter.tsx
+++ b/app/javascript/react_app/components/filters/family_and_order_filter.tsx
@@ -58,7 +58,7 @@ const FamilyAndOrderFilter: React.FC<FamilyAndOrderFilterProps> = (props) => {
   )
 
   return (
-    <>
+    <div id='filter-selects'>
       <Select
         id='select-order'
         ariaLabel='Select order to filter the birds by'
@@ -75,7 +75,7 @@ const FamilyAndOrderFilter: React.FC<FamilyAndOrderFilterProps> = (props) => {
         handleChange={handleFamilyChange}
         selectedValue={selectedFamilyOption}
       />
-    </>
+    </div>
   )
 }
 

--- a/app/javascript/react_app/components/filters/family_and_order_filter.tsx
+++ b/app/javascript/react_app/components/filters/family_and_order_filter.tsx
@@ -60,7 +60,6 @@ const FamilyAndOrderFilter: React.FC<FamilyAndOrderFilterProps> = (props) => {
   return (
     <>
       <Select
-        label='Orders'
         id='select-order'
         ariaLabel='Select order to filter the birds by'
         options={tranformToOptions(orders)}
@@ -69,7 +68,6 @@ const FamilyAndOrderFilter: React.FC<FamilyAndOrderFilterProps> = (props) => {
         selectedValue={selectedOrderOption}
       />
       <Select
-        label='Families'
         id='select-family'
         ariaLabel='Select a family to filter the birds by'
         options={tranformToOptions(filteredFamilies)}


### PR DESCRIPTION
By putting the order and family filter on the same row, the filter group component decreases in size, which means the user can focus on the Bird components more. Helps a lot with mobile UX. It is unnecessary to have them on different rows as the user as on desktop the user has plenty of space and on mobile, the select dropdown fills on the whole screen.

/ @RyanofWoods 