### PR TITLE
Fix search returning no birds when search query is one character

### DIFF
--- a/app/javascript/react_app/helpers/filter_birds.test.ts
+++ b/app/javascript/react_app/helpers/filter_birds.test.ts
@@ -47,6 +47,14 @@ test('when the searchScope is empty because the search query results in no birds
   expect(actual).toEqual([])
 })
 
+test('when the searchScope is empty because the trigram search return nothing on one character searches, it returns all the birds', () => {
+  filters.searchScope = []
+  filters.searchValue = 't'
+
+  const actual = filterBirds({ birds, filters })
+  expect(actual).toEqual(birds)
+})
+
 test('when seenScope is "seen" it returns only seen birds', () => {
   filters.seenScope = 'seen'
 

--- a/app/javascript/react_app/helpers/filter_birds.ts
+++ b/app/javascript/react_app/helpers/filter_birds.ts
@@ -7,7 +7,7 @@ interface Options {
 
 const filterBirds = ({ birds, filters }: Options): BirdWithOrWithoutObservation[] => {
   const { searchScope, seenScope, familyScientificNameScope, orderScientificNameScope } = filters
-  if (filters.searchScope.length === 0 && filters.searchValue.length > 0) return []
+  if (filters.searchScope.length === 0 && filters.searchValue.length > 1) return []
 
   return birds.filter(bird => {
     if (searchScope.length > 0) {


### PR DESCRIPTION
Because of the type of search the backend is using (trigram), a result
of no birds is returned when the search query is only one character in
length.

Generally, filterBirds wants to iterate over each bird and then check
if they are included in the search result (searchScope). However, there
is a guard clause at the start of the method, to return an empty array
when the result is nothing, to prevent unnecessary iterations. Before,
this guard also checked that the query was at least one character in
length, but to fix this it will be changed to at least two characters.