### PR TITLE
Add editObservation functionality

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,2 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link application.css

--- a/app/assets/stylesheets/all.scss
+++ b/app/assets/stylesheets/all.scss
@@ -20,3 +20,15 @@ h4 {
 .bold-600 {
   font-weight: 600;
 }
+
+.link {
+  color: $green;
+  text-decoration: underline;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    color: $dark-brown;
+  }
+}

--- a/app/assets/stylesheets/components/_bird.scss
+++ b/app/assets/stylesheets/components/_bird.scss
@@ -32,14 +32,7 @@
 }
 
 #details-link {
-  color: $green;
-  text-decoration: underline;
-  font-size: 0.75rem;
-  font-weight: 600;
   cursor: pointer;
   margin-top: 0.2rem;
-
-  &:hover {
-    color: $dark-brown;
-  }
 }
+

--- a/app/assets/stylesheets/components/_bird.scss
+++ b/app/assets/stylesheets/components/_bird.scss
@@ -13,6 +13,7 @@
   }
   
   .bird-date {
+    color: inherit;
     display: flex;
     flex-direction: column;
     font-size: 0.75rem;

--- a/app/javascript/react_app/api/index.ts
+++ b/app/javascript/react_app/api/index.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { fetchBirdsResponse, createObservationResponse, createObservationRequest, searchBirdsResponse, fetchOrdersResponse, fetchFamiliesResponse } from '../types/api'
+import { fetchBirdsResponse, createObservationResponse, createObservationRequest, editObservationRequest, editObservationResponse, searchBirdsResponse, fetchOrdersResponse, fetchFamiliesResponse } from '../types/api'
 import { client } from './client'
 
 export const fetchBirds = createAsyncThunk('birds/fetchBirds', async () => {
@@ -21,6 +21,14 @@ export const createObservation = createAsyncThunk(
   'birds/createObservation',
   async (args: createObservationRequest) => {
     const response = await client.post<createObservationResponse>(`/birds/${args.birdScientificName}/observations`, { observed_at: args.observedAt, note: args.note })
+    return response.result
+  }
+)
+
+export const editObservation = createAsyncThunk(
+  'birds/editObservation',
+  async (args: editObservationRequest) => {
+    const response = await client.patch<editObservationResponse>(`/observations/${args.birdScientificName}`, { observed_at: args.observedAt, note: args.note })
     return response.result
   }
 )

--- a/app/javascript/react_app/components/bird/bird.tsx
+++ b/app/javascript/react_app/components/bird/bird.tsx
@@ -42,7 +42,7 @@ const Bird: React.FC<BirdProps> = ({ bird, userSettings }) => {
       <div className='bird-names'>
         <p className='bold-600 m-0'>{getNameAttribute(bird, userSettings.primaryNameLanguage)}</p>
         <p>{getNameAttribute(bird, userSettings.secondaryNameLanguage)}</p>
-        <a id='details-link' onClick={toggleDetailsModal}>Details</a>
+        <a id='details-link' className='link' onClick={toggleDetailsModal}>Details</a>
       </div>
       <div onMouseOver={handleMouseIn} onMouseOut={handleMouseOut} className='position-relative' role='button'>
         <PopulationBars population={bird.populationCategory} />

--- a/app/javascript/react_app/components/bird/checkbox_and_date.tsx
+++ b/app/javascript/react_app/components/bird/checkbox_and_date.tsx
@@ -31,9 +31,9 @@ const CheckboxAndDate: React.FC<CheckboxAndDateProps> = ({ bird, toggleSeenModal
     }
 
     return (
-      <div className='bird-date'>
+      <a className='bird-date' onClick={toggleSeenModal}>
         {dateContents()}
-      </div>
+      </a>
     )
   }
 

--- a/app/javascript/react_app/components/bird/details_modal.tsx
+++ b/app/javascript/react_app/components/bird/details_modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Modal from '../shared/modal'
 
 import { BirdWithOrWithoutObservation, UserSettings } from '../../types'
@@ -6,6 +6,7 @@ import PopulationBars from './population_bars'
 import { populationInfo, migrationText } from '../../helpers/population_info'
 import BirdHouse from './bird_house'
 import getNameAttribute from '../../helpers/name_helper'
+import ObservationModal from './observation_modal'
 
 interface DetailsModalProps {
   close: () => void
@@ -14,6 +15,12 @@ interface DetailsModalProps {
 }
 
 const DetailsModal: React.FC<DetailsModalProps> = ({ close, bird, userSettings }) => {
+  const [showObservationModal, setShowObservationModal] = useState(false)
+
+  const toggleObservationModal = (): void => {
+    setShowObservationModal((prevState) => !prevState)
+  }
+
   const observationDetails = (): JSX.Element | undefined => {
     if (bird.observation != null) {
       let dateText
@@ -36,7 +43,8 @@ const DetailsModal: React.FC<DetailsModalProps> = ({ close, bird, userSettings }
 
       return (
         <>
-          <h4 className='mt-4'>My first observation</h4>
+          <h4 className='mt-4 d-inline'>My first observation</h4>
+          <a className='ml-3 link' onClick={toggleObservationModal}>Edit</a>
           {dateText}
           <h4 className='mt-4'>Note</h4>
           <p>{noteText}</p>
@@ -78,6 +86,11 @@ const DetailsModal: React.FC<DetailsModalProps> = ({ close, bird, userSettings }
           Close
         </button>
       </div>
+      {
+        showObservationModal && (
+          <ObservationModal close={toggleObservationModal} bird={bird} userSettings={userSettings} />
+        )
+      }
     </Modal>
   )
 }

--- a/app/javascript/react_app/components/bird/observation_modal.tsx
+++ b/app/javascript/react_app/components/bird/observation_modal.tsx
@@ -20,7 +20,7 @@ const ObservationModal: React.FC<ObservationModalProps> = ({ close, bird, userSe
   const [note, setNote] = useState('')
   const [dateUnknown, setDateUnknown] = useState(false)
 
-  const handleMarkSeen = (): void => {
+  const handleObservation = (): void => {
     const observationDate = (observedAt === '') ? 0 : observedAt
     void dispatch(createObservation({
       birdScientificName: bird.scientificName,
@@ -45,7 +45,7 @@ const ObservationModal: React.FC<ObservationModalProps> = ({ close, bird, userSe
 
   const handleConfirm = (event: React.FormEvent<HTMLFormElement>): void => {
     event.preventDefault()
-    handleMarkSeen()
+    handleObservation()
     close()
   }
 

--- a/app/javascript/react_app/components/bird/observation_modal.tsx
+++ b/app/javascript/react_app/components/bird/observation_modal.tsx
@@ -21,7 +21,7 @@ const ObservationModal: React.FC<ObservationModalProps> = ({ close, bird, userSe
   const [dateUnknown, setDateUnknown] = useState(false)
 
   const handleObservation = (): void => {
-    const observationDate = (observedAt === '') ? 0 : observedAt
+    const observationDate = (dateUnknown) ? 0 : observedAt
     void dispatch(createObservation({
       birdScientificName: bird.scientificName,
       observedAt: observationDate,

--- a/app/javascript/react_app/features/birdSlice.ts
+++ b/app/javascript/react_app/features/birdSlice.ts
@@ -38,6 +38,17 @@ const resortBirds = (state: State): void => {
   state.sortedBirds = sortBirds({ birds: state.filteredBirds, sorting: state.sorting, primaryNameLanguage: state.userSettings.primaryNameLanguage })
 }
 
+const updateAllBirds = (state: State, updatedBird: BirdWithOrWithoutObservation): void => {
+  updateBirds(state.birds, updatedBird)
+  updateBirds(state.filteredBirds, updatedBird)
+  updateBirds(state.sortedBirds, updatedBird)
+}
+
+const updateBirds = (birds: BirdWithOrWithoutObservation[], updatedBird: BirdWithOrWithoutObservation): void => {
+  const birdToUpdateIndex = birds.findIndex(bird => bird.scientificName === updatedBird.scientificName)
+  birds[birdToUpdateIndex] = updatedBird
+}
+
 export const birdSlice = createSlice({
   name: 'bird',
   initialState,
@@ -67,13 +78,7 @@ export const birdSlice = createSlice({
       state.orders = payload.orders
     })
     builder.addCase(createObservation.fulfilled, (state, { payload }) => {
-      const updateBirds = (birds: BirdWithOrWithoutObservation[]): void => {
-        const birdToUpdateIndex = birds.findIndex(bird => bird.scientificName === payload.scientificName)
-        birds[birdToUpdateIndex] = payload
-      }
-      updateBirds(state.birds)
-      updateBirds(state.filteredBirds)
-      updateBirds(state.sortedBirds)
+      updateAllBirds(state, payload)
     })
     builder.addCase(searchBirds.pending, (state, action) => {
       state.filters.searchValue = action.meta.arg

--- a/app/javascript/react_app/features/birdSlice.ts
+++ b/app/javascript/react_app/features/birdSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { fetchBirds, createObservation, searchBirds, fetchOrders, fetchFamilies } from '../api'
+import { fetchBirds, createObservation, editObservation, searchBirds, fetchOrders, fetchFamilies } from '../api'
 import filterBirds from '../helpers/filter_birds'
 import clickSortingColumn from '../helpers/click_sorting_column'
 import { sortBirds } from '../helpers/sort_birds'
@@ -78,6 +78,9 @@ export const birdSlice = createSlice({
       state.orders = payload.orders
     })
     builder.addCase(createObservation.fulfilled, (state, { payload }) => {
+      updateAllBirds(state, payload)
+    })
+    builder.addCase(editObservation.fulfilled, (state, { payload }) => {
       updateAllBirds(state, payload)
     })
     builder.addCase(searchBirds.pending, (state, action) => {

--- a/app/javascript/react_app/types/api.ts
+++ b/app/javascript/react_app/types/api.ts
@@ -17,8 +17,14 @@ export interface createObservationRequest {
   observedAt: string | 0
   note?: string | null
 }
+export interface editObservationRequest {
+  birdScientificName: BirdScientificName
+  observedAt?: string | 0
+  note?: string | null
+}
 
 export interface createObservationResponse extends BirdWithObservation {}
+export interface editObservationResponse extends BirdWithObservation {}
 
 export interface searchBirdsResponse {
   birds: BirdScientificName[]


### PR DESCRIPTION
The user can not edit their observations. Clicking on `edit` in the bird's detailsModal or the `observedAt` date in the bird card will open up the observationModal which now has the functionality to edit observations.

See commits for more details.