### PR TITLE
Change second observation modal button from Close to Cancel

### DIFF
--- a/app/javascript/react_app/components/bird/observation_modal.tsx
+++ b/app/javascript/react_app/components/bird/observation_modal.tsx
@@ -92,7 +92,7 @@ const ObservationModal: React.FC<ObservationModalProps> = ({ close, bird, userSe
             Confirm
           </button>
           <button type='button' className='btn btn-dark' onClick={close}>
-            Close
+            Cancel
           </button>
         </div>
       </form>


### PR DESCRIPTION
I think it is clearer if it says Cancel instead of Close on the second button in the observation modal.