### PR TITLE
Update bottom margin of reset-filter

### DIFF
--- a/app/assets/stylesheets/components/_counter.scss
+++ b/app/assets/stylesheets/components/_counter.scss
@@ -1,5 +1,5 @@
 .counter-section {
-  margin-bottom: 32px;
+  margin-bottom: 2rem;
   p {
     margin: 0;
   }

--- a/app/assets/stylesheets/components/_reset_filter.scss
+++ b/app/assets/stylesheets/components/_reset_filter.scss
@@ -1,7 +1,6 @@
 #reset-filter {
-  margin-bottom: 32px;
+  margin-bottom: 2rem;
   color: $green;
-  margin-bottom: 20px;
   text-decoration: underline;
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
Bottom margin of reset-filter-button was incorrect and updated to 2rem. I also replaced bottom margin of the counter-section to rem instead of px.