### PR TITLE
Fix modal padding and margins

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -20,7 +20,15 @@
     color: $dark-brown;
     opacity: 1;
   }
-
+  .modal-footer {
+    padding: 0 1rem 1rem 1rem;
+    & :not(:first-child) {
+      margin-top: 8px;
+    }
+    &  > * {
+      margin: 0;
+    }
+  }
   .modal-header, .modal-footer {
     border: none;
   }

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -39,13 +39,6 @@
 @media (max-width: 576px) {
   .modal-component {
     max-width: 90vw;
-
-    .modal-header {
-      padding: 0.25rem 1rem;
-    }
-    .modal-body {
-      padding: 0.5rem 0 0.5rem 0;
-    }
   }
 }
 @media (max-width: 350px) {

--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -35,17 +35,6 @@
       width: 100%;
     }
   }
-  .contentGroup {
-    padding-top: 20px;
-    
-    .detailsModalItem {
-      display: flex;
-      
-      & > :first-child {
-        min-width: 50px;
-      }
-    }
-  }
 }
 @media (max-width: 576px) {
   .modal-component {
@@ -57,17 +46,10 @@
     .modal-body {
       padding: 0.5rem 0 0.5rem 0;
     }
-    & .detailsModalContent .contentGroup {
-        padding-top: 8px;
-    }
   }
 }
 @media (max-width: 350px) {
   .modal-component {
     max-width: 100vw;
-
-    & .detailsModalContent .contentGroup {
-      padding-top: 0px;
-    }
   }
 }

--- a/app/javascript/react_app/components/bird/details_modal.tsx
+++ b/app/javascript/react_app/components/bird/details_modal.tsx
@@ -64,7 +64,7 @@ const DetailsModal: React.FC<DetailsModalProps> = ({ close, bird, userSettings }
     <Modal title='Bird details' close={close}>
       <div className='detailsModalContent modal-body'>
 
-        <h4 className='mt-2'>Name</h4>
+        <h4>Name</h4>
         <p className='bold-600 m-0'>{getNameAttribute(bird, userSettings.primaryNameLanguage)}</p>
         <p className='m-0'>{getNameAttribute(bird, userSettings.secondaryNameLanguage)}</p>
 

--- a/app/javascript/react_app/components/bird/observation_modal.tsx
+++ b/app/javascript/react_app/components/bird/observation_modal.tsx
@@ -69,7 +69,7 @@ const ObservationModal: React.FC<ObservationModalProps> = ({ close, bird, userSe
     <Modal title={title} close={close}>
       <form onSubmit={handleConfirm}>
         <div className='modal-body'>
-          <h4 className='mt-2'>Name</h4>
+          <h4>Name</h4>
           <p className='bold-600 m-0'>{getNameAttribute(bird, userSettings.primaryNameLanguage)}</p>
           <p className='m-0'>{getNameAttribute(bird, userSettings.secondaryNameLanguage)}</p>
           <div className='d-flex align-items-end'>


### PR DESCRIPTION
- Fix inconsistent margin and paddings in the modals
- Due to buttons being stacked, bootstrap's margin of 4px on the buttons themselves had to be fixed
- Not using a border between body and footer created too much space and therefore I removed the top padding on the footer
