### PR TITLE
Show error on rejected api actions

### DIFF
--- a/app/javascript/react_app/api/client.ts
+++ b/app/javascript/react_app/api/client.ts
@@ -54,9 +54,10 @@ export async function client<T> (method: RequestType, endpoint: string, data: Da
         url: response.url
       }
     }
-    throw new Error(response.statusText)
+    return await Promise.reject(result.error)
   } catch (err: any) {
-    return await Promise.reject(err.message ?? result)
+    const errorMessage = err ?? 'Something went wrong.'
+    return await Promise.reject(errorMessage)
   }
 }
 

--- a/app/javascript/react_app/features/flashMessageSlice.ts
+++ b/app/javascript/react_app/features/flashMessageSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { createObservation, editObservation } from '../api'
 import { FlashMessageState } from '../types/flashMessageData'
 
 const initialState: FlashMessageState = {
@@ -12,6 +13,14 @@ export const flashMessageSlice = createSlice({
     clearFlashMessage (state) {
       state.flashMessage = null
     }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(createObservation.rejected, (state, { error }) => {
+      state.flashMessage = { type: 'error', message: (error.message as string) }
+    })
+    builder.addCase(editObservation.rejected, (state, { error }) => {
+      state.flashMessage = { type: 'error', message: (error.message as string) }
+    })
   }
 })
 


### PR DESCRIPTION
Now, if the API actions are not successful, it will use the returned
error (or a default error) response to render a FlashMessage to the user.