### PR TITLE
Remove react app logged in restrictions

### DIFF
--- a/app/controllers/api/birds_controller.rb
+++ b/app/controllers/api/birds_controller.rb
@@ -1,6 +1,8 @@
 class Api::BirdsController < Api::BaseController
+  before_action :no_authentication_required, only: [:index]
+
   def index
     @birds = Bird.all.includes(family: :order)
-    @observations = current_user.observations
+    @observations = user_signed_in? ? current_user.observations : Observation.none
   end
 end

--- a/app/controllers/api/families_controller.rb
+++ b/app/controllers/api/families_controller.rb
@@ -1,4 +1,6 @@
 class Api::FamiliesController < Api::BaseController
+  before_action :no_authentication_required, only: [:index]
+
   def index
     @families = Family.all.includes(:order)
   end

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -1,4 +1,6 @@
 class Api::OrdersController < Api::BaseController
+  before_action :no_authentication_required, only: [:index]
+
   def index
     @orders = Order.all
   end

--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,4 +1,6 @@
 class Api::SearchController < Api::BaseController
+  before_action :no_authentication_required, only: [:index]
+
   def index
     @birds = Bird.search_by_all_names(params[:query])
   end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::UsersController < Api::BaseController
-  before_action :no_authentication_required
+  before_action :no_authentication_required, only: [:index]
 
   def index
     render json: { isLoggedIn: signed_in? }, status: :ok

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,4 @@
 class PagesController < ApplicationController
   def react
-    redirect_to new_user_session_path unless user_signed_in?
   end
 end

--- a/test/controllers/api/birds_controller_test.rb
+++ b/test/controllers/api/birds_controller_test.rb
@@ -11,12 +11,45 @@ class Api::BirdsControllerTest < ActionDispatch::IntegrationTest
     @other_user.observations.create!(bird: birds(:white_backed_woodpecker), observed_at: '2022-01-02')
   end
 
-  test 'GET #index returns an unauthorized response if not logged in' do
+  test 'GET #index returns all birds with no observations joined on when not logged in' do
     get api_birds_url
 
-    assert_response :unauthorized
-    expected = { 'error'=> 'You need to sign in or sign up before continuing.' }
-    assert_equal(expected, json_response)
+    assert_response :success
+    expected_birds = [
+      {
+        'scientificName'=> birds(:great_spotted_woodpecker).scientific_name,
+        'englishName'=> birds(:great_spotted_woodpecker).english_name,
+        'swedishName'=> birds(:great_spotted_woodpecker).swedish_name,
+        'familyScientificName'=> birds(:great_spotted_woodpecker).family.scientific_name,
+        'orderScientificName'=> birds(:great_spotted_woodpecker).family.order.scientific_name,
+        'details'=> birds(:great_spotted_woodpecker).details,
+        'populationCategory'=> birds(:great_spotted_woodpecker).population_category,
+        'seen'=> false
+      },
+      {
+        'scientificName'=> birds(:green_woodpecker).scientific_name,
+        'englishName'=> birds(:green_woodpecker).english_name,
+        'swedishName'=> birds(:green_woodpecker).swedish_name,
+        'familyScientificName'=> birds(:green_woodpecker).family.scientific_name,
+        'orderScientificName'=> birds(:green_woodpecker).family.order.scientific_name,
+        'details'=>  birds(:green_woodpecker).details,
+        'populationCategory'=>  birds(:green_woodpecker).population_category,
+        'seen'=> false
+      },
+      {
+        'scientificName'=> birds(:white_backed_woodpecker).scientific_name,
+        'englishName'=> birds(:white_backed_woodpecker).english_name,
+        'swedishName'=> birds(:white_backed_woodpecker).swedish_name,
+        'familyScientificName'=> birds(:white_backed_woodpecker).family.scientific_name,
+        'orderScientificName'=> birds(:white_backed_woodpecker).family.order.scientific_name,
+        'details'=>  birds(:white_backed_woodpecker).details,
+        'populationCategory'=>  birds(:white_backed_woodpecker).population_category,
+        'seen'=> false
+      }
+    ]
+
+    actual_birds = json_response['birds']
+    expected_birds.each { |bird| assert_includes(actual_birds, bird) }
   end
 
   test 'GET #index returns all birds with any user observations joined on' do

--- a/test/controllers/api/families_controller_test.rb
+++ b/test/controllers/api/families_controller_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class Api::FamiliesControllerTest < ActionDispatch::IntegrationTest
 
-  test 'GET #index returns an unauthorized response if not logged in' do
+  test 'GET #index returns all the Families if not logged in' do
     get api_families_url
 
-    assert_response :unauthorized
-    expected = { 'error'=> 'You need to sign in or sign up before continuing.' }
-    assert_equal(expected, json_response)
+    assert_response :success
+    actual = json_response['families']
+    assert_equal(actual.size, Family.all.size)
   end
 
   test 'GET #index returns all the Families' do

--- a/test/controllers/api/orders_controller_test.rb
+++ b/test/controllers/api/orders_controller_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class Api::OrdersControllerTest < ActionDispatch::IntegrationTest
 
-  test 'GET #index returns an unauthorized response if not logged in' do
+  test 'GET #index returns all the Orders if not logged in' do
     get api_orders_url
 
-    assert_response :unauthorized
-    expected = { 'error'=> 'You need to sign in or sign up before continuing.' }
-    assert_equal(expected, json_response)
+    assert_response :success
+    actual = json_response['orders']
+    assert_equal(actual.size, Order.all.size)
   end
 
   test 'GET #index returns all the Orders' do

--- a/test/controllers/api/search_controller_test.rb
+++ b/test/controllers/api/search_controller_test.rb
@@ -5,11 +5,12 @@ class Api::SearchControllerTest < ActionDispatch::IntegrationTest
     @user = users(:ryan)
   end
 
-  test 'POST #create returns an unauthorized response if there is no logged in user' do
+  test 'GET #index returns all the matching bird scientific names if not logged in' do
     get api_search_url(query: 'tit')
 
-    assert_response :unauthorized
-    expected = { 'error'=> 'You need to sign in or sign up before continuing.' }
+    assert_response :success
+    birds = Bird.search_by_all_names('tit')
+    expected = { 'birds'=> birds.pluck(:scientific_name) }
     assert_equal(expected, json_response)
   end
 

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -7,8 +7,8 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'redirected to login if not logged in' do
+  test 'success if not logged in' do
     get '/'
-    assert_redirected_to controller: 'devise/sessions', action: 'new'
+    assert_response :success
   end
 end


### PR DESCRIPTION
Now any user, logged in or not can access the react app and see the birds.

If a non-logged in user attempts to click a bird checkbox to create an observation, they will be warned by a flash message that they need to log in for that feature.

This should help encourage users to sign up to the website, as they can see what the app is like without having to sign up first. It also widens the site's audience as users could just use the site for the bird list but not for observations.