### PR TITLE
Improve serialized array test assertion fail messages

### DIFF
--- a/test/controllers/api/birds_controller_test.rb
+++ b/test/controllers/api/birds_controller_test.rb
@@ -49,7 +49,7 @@ class Api::BirdsControllerTest < ActionDispatch::IntegrationTest
     ]
 
     actual_birds = json_response['birds']
-    expected_birds.each { |bird| assert_includes(actual_birds, bird) }
+    assert_serialized_array(expected_birds, actual_birds, 'englishName')
   end
 
   test 'GET #index returns all birds with any user observations joined on' do
@@ -100,6 +100,6 @@ class Api::BirdsControllerTest < ActionDispatch::IntegrationTest
     ]
 
     actual_birds = json_response['birds']
-    expected_birds.each { |bird| assert_includes(actual_birds, bird) }
+    assert_serialized_array(expected_birds, actual_birds, 'englishName')
   end
 end

--- a/test/support/api_test_helpers.rb
+++ b/test/support/api_test_helpers.rb
@@ -2,4 +2,15 @@ module ApiTestHelpers
   def json_response
     JSON.parse(response.body)
   end
+
+  def assert_serialized_array(expected, actual, contextual_attribute)
+    simplified_actual = actual.map { |object| object[contextual_attribute] }
+
+    expected.each do |expected_object|
+      simplified_expected = expected_object[contextual_attribute]
+      assert_includes(simplified_actual, simplified_expected)
+      actual_object = actual.find { |object| object[contextual_attribute] == simplified_expected }
+      assert_equal(expected_object, actual_object)
+    end
+  end
 end


### PR DESCRIPTION
Before, it was very difficult to read the fail messages regarding
serialized arrays.

1. Because you have to locate where the expected item is in the array
2. It might not even be in there
3. If it is, it's difficult to see clearly what attributes are different

Now, with this helper, you give the actual, expected and a useful attribute
name, then it will check if the item is even in the array, and then if
it is, it will assert if is what you expect it should be.

This produces easy to read error messages for both key areas:
- element inclusion; and
- element equality.