### PR TITLE
Add reset search bar button

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -18,4 +18,5 @@
 @import "population_bars";
 @import "population_tooltip";
 @import "reset_filter";
+@import "search";
 @import "sorting_header";

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -1,0 +1,15 @@
+.search-container {
+  position: relative;
+
+  input {
+    padding-right: 2rem;
+  }
+
+  button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    padding: 0.5rem 0.75rem 0.5rem 0.5rem;
+  }
+}

--- a/app/javascript/react_app/components/filters/search_bar.tsx
+++ b/app/javascript/react_app/components/filters/search_bar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { searchBirds } from '../../api'
+import { resetSearch } from '../../features/birdSlice'
 import { useAppDispatch } from '../../hooks'
 
 import Input from '../shared/input'
@@ -15,17 +16,25 @@ const SearchBar: React.FC<SearchBarProps> = ({ searchValue }) => {
     void dispatch(searchBirds(event.target.value))
   }
 
+  const resetSearchBar = (): void => {
+    void dispatch(resetSearch())
+  }
+
   return (
     <>
       <Input
-        formGroupClasses='mt-0'
+        formGroupClasses='mt-0 search-container'
         id='search'
         type='text'
         ariaLabel='search for a bird'
         placeholder='Search for a bird...'
         handleChange={handleChange}
         value={searchValue}
-      />
+      >
+        <button type='button' className='close' aria-label='Reset search bar' onClick={resetSearchBar}>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </Input>
     </>
   )
 }

--- a/app/javascript/react_app/components/shared/input.tsx
+++ b/app/javascript/react_app/components/shared/input.tsx
@@ -11,10 +11,11 @@ interface InputProps {
   handleFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   value: string
   formGroupClasses?: string
+  children?: JSX.Element
 }
 
 const Input: React.FC<InputProps> = (props) => {
-  const { label, id, ariaLabel, placeholder, type, handleChange, handleBlur, handleFocus, value, formGroupClasses } = props
+  const { label, id, ariaLabel, placeholder, type, handleChange, handleBlur, handleFocus, value, formGroupClasses, children } = props
 
   return (
     <div className={`form-group ${formGroupClasses ?? ''}`}>
@@ -30,6 +31,7 @@ const Input: React.FC<InputProps> = (props) => {
         onFocus={handleFocus}
         value={value}
       />
+      {children}
     </div>
   )
 }

--- a/app/javascript/react_app/features/birdSlice.ts
+++ b/app/javascript/react_app/features/birdSlice.ts
@@ -61,6 +61,11 @@ export const birdSlice = createSlice({
       state.filters = initialState.filters
       refilterBirds(state)
     },
+    resetSearch (state) {
+      state.filters.searchValue = ''
+      state.filters.searchScope = []
+      refilterBirds(state)
+    },
     updateSorting (state, action: PayloadAction<BirdColumn>) {
       state.sorting = clickSortingColumn({ sorting: state.sorting, clickedHeader: action.payload })
       resortBirds(state)
@@ -93,5 +98,5 @@ export const birdSlice = createSlice({
   }
 })
 
-export const { resetFilters, updateFilters, updateSorting } = birdSlice.actions
+export const { resetFilters, resetSearch, updateFilters, updateSorting } = birdSlice.actions
 export default birdSlice


### PR DESCRIPTION
Allow for resetting the search bar for a better UX. As a bonus, this
will also reduce the amount of API calls to the backend, as it's
currently done onChange, which means also on deleting characters.