### PR TITLE
Fix Safari date bug

### DIFF
--- a/app/javascript/react_app/components/bird/checkbox_and_date.tsx
+++ b/app/javascript/react_app/components/bird/checkbox_and_date.tsx
@@ -17,8 +17,8 @@ const CheckboxAndDate: React.FC<CheckboxAndDateProps> = ({ bird, handleChange })
       if (bird.observation.observedAt === null) {
         return <p>Seen</p>
       } else {
-        const month = bird.observation.observedAt.substring(5, 7)
-        const monthFormatted = Intl.DateTimeFormat('en', { month: 'short' }).format(new Date(month))
+        const parsedDate = new Date(bird.observation.observedAt)
+        const monthFormatted = Intl.DateTimeFormat('en', { month: 'short' }).format(parsedDate)
 
         return (
           <>

--- a/app/javascript/react_app/components/bird/details_modal.tsx
+++ b/app/javascript/react_app/components/bird/details_modal.tsx
@@ -30,8 +30,9 @@ const DetailsModal: React.FC<DetailsModalProps> = ({ close, bird, userSettings }
       if (observedAt === null) {
         dateText = <p className='date'>Date unknown</p>
       } else {
-        const month = observedAt.substring(5, 7)
-        const monthFormatted = Intl.DateTimeFormat('en', { month: 'long' }).format(new Date(month))
+        const parsedDate = new Date(observedAt)
+        const monthFormatted = Intl.DateTimeFormat('en', { month: 'long' }).format(parsedDate)
+
         dateText = (
           <div className='d-flex'>
             <p className='date'>{observedAt.substring(8, 10)}</p>


### PR DESCRIPTION
These areas of code were relying on passing a string month to the JS Date constructor such as '09'. However, this acts differently depending on the browser. For example:

Chrome:
```
new Date('09')
Sat Sep 01 2001 00:00:00 GMT+0200 (Central European Summer Time)
```

Safari:
```
new Date('09')
Thu Jan 01 0009 00:53:28 GMT+0053 (CET) = $1
```

Instead of using a string month to get a date with that month, we can just parse the string date directly to avoid this problem.

This bug caused the month to always be January on Safari (iOS and Desktop).