### PR TITLE
Run yarn install on fly Docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -p tmp/pids
 RUN curl https://get.volta.sh | bash
 ENV VOLTA_HOME /root/.volta
 ENV PATH $VOLTA_HOME/bin:/usr/local/bin:$PATH
-RUN volta install node@${NODE_VERSION}
+RUN volta install node@${NODE_VERSION} yarn@1.22.19;
 
 #######################################################################
 


### PR DESCRIPTION
As Webpacker runs yarn install before precompiling assets, we need yarn in the base image, otherwise the build will fail.

```
 > [stage-4 8/8] RUN bin/rails fly:build:
 #27 4.026 Volta error: Yarn is not available.
 #27 4.026
 #27 4.026 Use `volta install yarn` to select a default version (see `volta help install` for more info).
```