### PR TITLE
Move modal-container out of page-container

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,12 +26,11 @@
   </head>
 
   <body>
+    <div id="modal-container">
+    </div>
     <div id="page-container">
       <div id="navbar-container">
       </div>
-      <div id="modal-container">
-      </div>
-      
       <div id="content-container">
         <div class="container my-5">
           <div class="row justify-content-center">


### PR DESCRIPTION
There's some CSS on the page-container [1], to cause its contents to grow in size to ensure that the footer is always the bottom of the page/not float in the middle. When the content-container was too short in height to fillup the viewport, it triggered the CSS to increase the height of the modal-container, which meant empty space above the filters when no Birds were rendered.

[1] https://github.com/RyanofWoods/rails-react-swedish-birds/blob/5119a02ef182d02637a4587ba4988a2457e321f2/app/assets/stylesheets/components/_container.scss#L4

| Description | Screenshot |
|--|--|
| When content-container is large | <img width="1728" alt="Screenshot 2023-05-26 at 13 27 52" src="https://github.com/RyanofWoods/rails-react-swedish-birds/assets/76776099/740ee41c-e27a-4c4b-aeb6-56afbcc1db4e"> |
| Before, when the content-container is small | <img width="1728" alt="Screenshot 2023-05-26 at 13 28 15" src="https://github.com/RyanofWoods/rails-react-swedish-birds/assets/76776099/b3f31a53-6cf7-49ea-960a-6bfb3632ee31"> |
| After, when the content-container is small | <img width="1728" alt="Screenshot 2023-05-26 at 13 27 59" src="https://github.com/RyanofWoods/rails-react-swedish-birds/assets/76776099/85ace15a-8046-4f4f-8252-d81533d16c10"> |