### PR TITLE
Move FilterGroup AppSelectors down the chain

### DIFF
--- a/app/javascript/react_app/components/filters/family_and_order_filter.tsx
+++ b/app/javascript/react_app/components/filters/family_and_order_filter.tsx
@@ -2,22 +2,18 @@ import React, { useEffect, useState } from 'react'
 
 import { updateFilters } from '../../features/speciesSlice'
 import getNameAttribute from '../../helpers/name_helper'
-import { useAppDispatch } from '../../hooks'
-import { Family, Order, FamilyScientificName, OrderScientificName, UserSettings } from '../../types/speciesData'
+import { useAppDispatch, useAppSelector } from '../../hooks'
+import { Family, Order, FamilyScientificName, OrderScientificName } from '../../types/speciesData'
 import Select, { Option } from '../shared/select'
 
-interface FamilyAndOrderFilterProps {
-  families: Family[]
-  orders: Order[]
-  userSettings: UserSettings
-  selectedOrderOption: string | null
-  selectedFamilyOption: string | null
-}
-
-const FamilyAndOrderFilter: React.FC<FamilyAndOrderFilterProps> = (props) => {
-  const { families, orders, userSettings, selectedOrderOption, selectedFamilyOption } = props
-
+const FamilyAndOrderFilter: React.FC = () => {
   const dispatch = useAppDispatch()
+  const orders = useAppSelector(state => state.speciesData.orders)
+  const families = useAppSelector(state => state.speciesData.families)
+  const userSettings = useAppSelector(state => state.speciesData.userSettings)
+  const selectedOrderOption = useAppSelector(state => state.speciesData.filters.orderScientificNameScope)
+  const selectedFamilyOption = useAppSelector(state => state.speciesData.filters.familyScientificNameScope)
+
   const [filteredFamilies, setFilteredFamilies] = useState(families)
 
   const updateFamiliesBySelectedOrder = (): void => {

--- a/app/javascript/react_app/components/filters/filter_group.tsx
+++ b/app/javascript/react_app/components/filters/filter_group.tsx
@@ -3,18 +3,10 @@ import React from 'react'
 import SearchBar from './search_bar'
 import SeenSpeciesFilter from './seen_species_filter'
 import FamilyAndOrderFilter from './family_and_order_filter'
-import { useAppSelector, useAppDispatch } from '../../hooks'
+import { useAppDispatch } from '../../hooks'
 import { resetFilters } from '../../features/speciesSlice'
 
 const FilterGroup: React.FC = () => {
-  const orders = useAppSelector(state => state.speciesData.orders)
-  const families = useAppSelector(state => state.speciesData.families)
-  const userSettings = useAppSelector(state => state.speciesData.userSettings)
-  const selectedOrderOption = useAppSelector(state => state.speciesData.filters.orderScientificNameScope)
-  const selectedFamilyOption = useAppSelector(state => state.speciesData.filters.familyScientificNameScope)
-  const selectedSeenValue = useAppSelector(state => state.speciesData.filters.seenScope)
-  const searchValue = useAppSelector(state => state.speciesData.filters.searchValue)
-
   const dispatch = useAppDispatch()
 
   const handleReset = (event: React.MouseEvent<HTMLElement>): void => {
@@ -24,9 +16,9 @@ const FilterGroup: React.FC = () => {
 
   return (
     <>
-      <SeenSpeciesFilter selectedValue={selectedSeenValue} />
-      <FamilyAndOrderFilter orders={orders} families={families} userSettings={userSettings} selectedOrderOption={selectedOrderOption} selectedFamilyOption={selectedFamilyOption} />
-      <SearchBar searchValue={searchValue} />
+      <SeenSpeciesFilter />
+      <FamilyAndOrderFilter />
+      <SearchBar />
       <div className='d-flex justify-content-end'>
         <button id='reset-filter' onClick={handleReset}>Reset filters</button>
       </div>

--- a/app/javascript/react_app/components/filters/search_bar.tsx
+++ b/app/javascript/react_app/components/filters/search_bar.tsx
@@ -1,16 +1,13 @@
 import React from 'react'
 import { searchSpecies } from '../../api'
 import { resetSearch } from '../../features/speciesSlice'
-import { useAppDispatch } from '../../hooks'
+import { useAppDispatch, useAppSelector } from '../../hooks'
 
 import Input from '../shared/input'
 
-interface SearchBarProps {
-  searchValue: string
-}
-
-const SearchBar: React.FC<SearchBarProps> = ({ searchValue }) => {
+const SearchBar: React.FC = () => {
   const dispatch = useAppDispatch()
+  const searchValue = useAppSelector(state => state.speciesData.filters.searchValue)
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     void dispatch(searchSpecies(event.target.value))

--- a/app/javascript/react_app/components/filters/seen_species_filter.tsx
+++ b/app/javascript/react_app/components/filters/seen_species_filter.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import FilterRadioButtonGroup, { RadioOption } from '../shared/filter_radio_group'
 import { updateFilters } from '../../features/speciesSlice'
-import { useAppDispatch } from '../../hooks'
+import { useAppDispatch, useAppSelector } from '../../hooks'
 import { SeenScope } from '../../types/speciesData'
 
-interface SeenSpeciesFilterProps {
-  selectedValue: SeenScope
-}
-
-const SeenSpeciesFilter: React.FC<SeenSpeciesFilterProps> = ({ selectedValue }) => {
+const SeenSpeciesFilter: React.FC = () => {
   const dispatch = useAppDispatch()
+  const selectedSeenValue = useAppSelector(state => state.speciesData.filters.seenScope)
 
   const options: Array<RadioOption<SeenScope>> = [
     { value: 'all', label: 'All species' },
@@ -22,7 +19,7 @@ const SeenSpeciesFilter: React.FC<SeenSpeciesFilterProps> = ({ selectedValue }) 
   }
 
   return (
-    <FilterRadioButtonGroup<SeenScope> options={options} arialabel='label' selectedValue={selectedValue} name='specieslist' handleOnChange={handleChange} />
+    <FilterRadioButtonGroup<SeenScope> options={options} arialabel='label' selectedValue={selectedSeenValue} name='specieslist' handleOnChange={handleChange} />
   )
 }
 


### PR DESCRIPTION
Before, because all the selected state values were in one file, when one updated it caused re-renders for all of the filter components. By moving them down to component they are used in, this is prevented.